### PR TITLE
Fix: DB Seed, Auth password validation and Explore page

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -26,6 +26,7 @@
         "bcrypt": "^6.0.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.4",
+        "dotenv": "^16.4.5",
         "helmet": "^8.1.0",
         "multer": "^2.1.1",
         "passport": "^0.7.0",
@@ -2534,6 +2535,18 @@
       "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0",
         "rxjs": "^7.1.0"
+      }
+    },
+    "node_modules/@nestjs/config/node_modules/dotenv": {
+      "version": "17.2.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
+      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/@nestjs/core": {
@@ -5490,9 +5503,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.2.3",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
-      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -5509,18 +5522,6 @@
       "dependencies": {
         "dotenv": "^16.4.5"
       },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
-    },
-    "node_modules/dotenv-expand/node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       },
@@ -10921,18 +10922,6 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/typeorm/node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/typeorm/node_modules/glob": {

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -11,7 +11,7 @@ import { ScheduleModule } from '@nestjs/schedule';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { MulterModule } from '@nestjs/platform-express';
 import { diskStorage } from 'multer';
-import { extname } from 'path';
+import { extname, resolve } from 'path';
 import { v4 as uuid } from 'uuid';
 
 import { UsersModule } from './modules/users/users.module';
@@ -24,7 +24,7 @@ import { MatchmakingModule } from './gateways/matchmaking/matchmaking.module';
 
 @Module({
   imports: [
-    ConfigModule.forRoot({ isGlobal: true, envFilePath: '.env' }),
+    ConfigModule.forRoot({ isGlobal: true, envFilePath: resolve(__dirname, '../.env') }),
 
     TypeOrmModule.forRootAsync({
       inject: [ConfigService],

--- a/backend/src/database/seeds/seed.ts
+++ b/backend/src/database/seeds/seed.ts
@@ -27,6 +27,7 @@ import { User } from '../../modules/users/user.entity';
 import { Subject } from '../../modules/subjects/subject.entity';
 import { Party } from '../../modules/parties/party.entity';
 import { PartyMember } from '../../modules/parties/party-member.entity';
+import { ChatMessage } from '../../modules/parties/chat-message.entity';
 
 // ─── Conexión ──────────────────────────────────────────────────────────────────
 const AppDataSource = new DataSource({
@@ -36,7 +37,7 @@ const AppDataSource = new DataSource({
   username: process.env.POSTGRES_USER     ?? 'studyquest',
   password: process.env.POSTGRES_PASSWORD ?? 'studyquest_pass',
   database: process.env.POSTGRES_DB       ?? 'studyquest',
-  entities: [User, Subject, Party, PartyMember],
+  entities: [User, Subject, Party, PartyMember, ChatMessage],
   synchronize: false,
   logging: false,
 });

--- a/backend/tsconfig.seed.json
+++ b/backend/tsconfig.seed.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "module": "CommonJS",
     "moduleResolution": "node",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "types": ["node"]
   },
   "include": ["src/database/seeds/**/*.ts", "src/modules/**/*.ts", "src/common/**/*.ts"]
 }

--- a/frontend/src/components/AuthForms.tsx
+++ b/frontend/src/components/AuthForms.tsx
@@ -71,6 +71,7 @@ export function RegisterForm({ onSwitchToLogin }: RegisterFormProps) {
   const nextStep = () => {
     if (step === 1) {
       if (!form.email || !form.password) { setLocalError('Completá todos los campos'); return }
+      if (form.password.length < 8) { setLocalError('La contraseña debe tener al menos 8 caracteres'); return }
       if (form.password !== form.confirmPassword) { setLocalError('Las contraseñas no coinciden'); return }
     }
     if (step === 2) {

--- a/frontend/src/services/subjectService.ts
+++ b/frontend/src/services/subjectService.ts
@@ -10,8 +10,8 @@ export interface SubjectQuery {
 
 export const subjectService = {
   async findAll(query: SubjectQuery = {}): Promise<Subject[]> {
-    const { data } = await api.get<Subject[]>('/subjects', { params: query })
-    return data
+    const { data } = await api.get<any>('/subjects', { params: query })
+    return data.items || data
   },
 
   async findById(id: string): Promise<Subject> {


### PR DESCRIPTION
- Fixes TypeORM Missing Entity metadata during seed process.
- Adds early-return and UI feedback for password length in the register flow.
- Fixes the crashing blank screen in /explore by properly reading the paginated items property received from the backend.