### PR TITLE
feat(parties): crear vista Mis Parties funcional con endpoint POST

### DIFF
--- a/backend/src/common/dto/index.ts
+++ b/backend/src/common/dto/index.ts
@@ -121,6 +121,11 @@ export class SendChatMessageDto {
   @IsString() @MinLength(1) @MaxLength(2000) text: string;
 }
 
+export class CreatePartyDto {
+  @IsOptional() @IsUUID() subjectId?: string;
+  @IsOptional() @IsNumber() @Min(2) @Max(8) maxMembers?: number;
+}
+
 // ─── Quests ───────────────────────────────────────────────────────────────────
 
 export class CreateQuestDto {

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -16,8 +16,10 @@ async function bootstrap() {
     : corsOriginRaw;
 
   app.use(helmet());
-  app.enableCors({ origin: corsOrigin, credentials: true });
-  app.useGlobalPipes(
+  app.enableCors({
+    origin: 'http://localhost:5173', // El puerto de tu frontend
+    credentials: true,
+  }); app.useGlobalPipes(
     new ValidationPipe({
       whitelist: true,
       forbidNonWhitelisted: true,

--- a/backend/src/modules/parties/parties.controller.ts
+++ b/backend/src/modules/parties/parties.controller.ts
@@ -12,7 +12,7 @@ import {
 import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { PartiesService } from './parties.service';
-import { SendChatMessageDto } from '../../common/dto';
+import { SendChatMessageDto, CreatePartyDto } from '../../common/dto';
 
 @ApiTags('parties')
 @ApiBearerAuth()
@@ -32,6 +32,15 @@ export class PartiesController {
     return this.partiesService.findByUser(req.user.userId);
   }
 
+  @Post()
+  @ApiOperation({ summary: 'Crear una party nueva (solo vos como líder)' })
+  createParty(@Request() req: any, @Body() dto: CreatePartyDto) {
+    return this.partiesService.createForUser(
+      req.user.userId,
+      dto.subjectId,
+      dto.maxMembers ?? 4,
+    );
+  }
   @Get(':id')
   findOne(@Param('id') id: string) {
     return this.partiesService.findById(id);

--- a/backend/src/modules/parties/parties.service.ts
+++ b/backend/src/modules/parties/parties.service.ts
@@ -51,6 +51,51 @@ export class PartiesService {
     });
   }
 
+  async createForUser(
+    userId: string,
+    subjectId?: string,
+    maxMembers = 4,
+  ): Promise<Party> {
+    // Si no se pasa subjectId, usamos la primera materia inscripta del usuario
+    let resolvedSubjectId = subjectId;
+    if (!resolvedSubjectId) {
+      const user = await this.userRepo.findOne({
+        where: { id: userId },
+        relations: ['enrolledSubjects'],
+      });
+      if (!user?.enrolledSubjects?.length) {
+        throw new BadRequestException(
+          'Necesitás tener al menos una materia inscripta para crear una party',
+        );
+      }
+      resolvedSubjectId = user.enrolledSubjects[0].id;
+    }
+
+    return this.dataSource.transaction(async (em) => {
+      const party = em.create(Party, {
+        subjectId: resolvedSubjectId,
+        maxMembers,
+        status: 'forming',
+      });
+      await em.save(party);
+
+      const leader = em.create(PartyMember, {
+        partyId: party.id,
+        userId,
+        isOnline: true,
+        role: 'leader',
+      });
+      await em.save(leader);
+
+      const result = await em.findOne(Party, {
+        where: { id: party.id },
+        relations: ['subject', 'members', 'members.user'],
+      });
+      if (!result) throw new NotFoundException('Error al crear la party');
+      return result;
+    });
+  }
+
   async findById(id: string): Promise<Party> {
     const party = await this.partyRepo.findOne({
       where: { id },

--- a/frontend/src/components/DashboardComponents.tsx
+++ b/frontend/src/components/DashboardComponents.tsx
@@ -96,7 +96,7 @@ export function SubjectCardGrid({ subjects }: { subjects: Subject[] }) {
 export function QuickActions() {
   const navigate = useNavigate()
   return (
-    <div className="quick-actions">
+    <div className="quick-actions" style={{ flexWrap: 'wrap' }}>
       <button className="quick-btn quick-btn-match" onClick={() => navigate('/matchmaking')}>
         <span className="quick-btn-icon">🎮</span>
         <span>Find Party</span>
@@ -104,6 +104,17 @@ export function QuickActions() {
       <button className="quick-btn quick-btn-explore" onClick={() => navigate('/subjects')}>
         <span className="quick-btn-icon">🔍</span>
         <span>Explorar</span>
+      </button>
+      <button 
+        className="quick-btn" 
+        style={{ 
+          background: 'linear-gradient(135deg, rgba(236,72,153,0.15), rgba(219,39,119,0.1))', 
+          borderColor: 'rgba(236,72,153,0.25)' 
+        }} 
+        onClick={() => navigate('/parties')}
+      >
+        <span className="quick-btn-icon">👥</span>
+        <span>Mis Parties</span>
       </button>
     </div>
   )

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,4 +1,4 @@
-﻿/* ============================================================
+/* ============================================================
    StudyQuest â€” Design System
    Dark gaming aesthetic Â· Mobile-first
    ============================================================ */
@@ -328,6 +328,28 @@ input, textarea, select { font-family: inherit; }
 .party-banner-label { font-size: 11px; color: var(--green); font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; }
 .party-banner-name { font-size: 15px; font-weight: 700; }
 
+.party-list { display: flex; flex-direction: column; gap: 12px; }
+.party-list-item { 
+  display: flex; 
+  align-items: center; 
+  gap: 14px; 
+  background: var(--bg-surface); 
+  border: 1px solid var(--border); 
+  border-radius: var(--radius-lg); 
+  padding: 16px; 
+  cursor: pointer; 
+  transition: all 0.2s; 
+}
+.party-list-item:hover { 
+  background: var(--bg-elevated); 
+  border-color: var(--accent); 
+  transform: translateY(-2px); 
+  box-shadow: var(--shadow-sm); 
+}
+.party-list-info { flex: 1; }
+.party-list-name { font-weight: 700; font-size: 16px; margin-bottom: 4px; }
+.party-list-meta { font-size: 13px; color: var(--text-muted); display: flex; align-items: center; gap: 8px; }
+.party-list-arrow { color: var(--text-muted); font-size: 20px; }
 .subject-grid { display: flex; flex-direction: column; gap: 10px; }
 .subject-card {
   display: flex;

--- a/frontend/src/pages/MatchPage.tsx
+++ b/frontend/src/pages/MatchPage.tsx
@@ -105,7 +105,7 @@ export default function MatchPage() {
           )}
           {status === 'empty' && (
             <motion.div key="empty" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
-              <EmptyState onCreateParty={() => navigate('/matchmaking')} />
+              <EmptyState onCreateParty={() => navigate('/parties')} />
             </motion.div>
           )}
           {showCard && top && (
@@ -136,7 +136,7 @@ export default function MatchPage() {
         disabled={!showCard}
       />
 
-      <CreatePartyBar onPress={() => navigate('/matchmaking')} />
+      <CreatePartyBar onPress={() => navigate('/parties')} />
 
       <BottomNav />
     </div>

--- a/frontend/src/pages/PartiesPage.tsx
+++ b/frontend/src/pages/PartiesPage.tsx
@@ -1,16 +1,174 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { MobileLayout } from '../components/Layouts'
-import { Badge } from '../components/UI'
+import { Spinner, Badge, Button } from '../components/UI'
+import { partyService, type Party } from '../services/partyService'
+import { useAuthStore } from '../store/authStore'
 
 const PartiesPage = () => {
+  const navigate = useNavigate()
+  const { user } = useAuthStore()
+  const [parties, setParties] = useState<Party[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [isCreating, setIsCreating] = useState(false)
+  const [showModal, setShowModal] = useState(false)
+  const [selectedSubjectId, setSelectedSubjectId] = useState<string>('')
+
+  const subjects = user?.enrolledSubjects ?? []
+
+  useEffect(() => {
+    let mounted = true
+    partyService.getMine()
+      .then((data) => {
+        if (mounted) {
+          setParties(data)
+          setIsLoading(false)
+        }
+      })
+      .catch((error) => {
+        console.error('Error fetching parties', error)
+        if (mounted) setIsLoading(false)
+      })
+    return () => { mounted = false }
+  }, [])
+
+  const handleCreate = async () => {
+    setIsCreating(true)
+    try {
+      const newParty = await partyService.create(selectedSubjectId || undefined)
+      navigate(`/party/${newParty.id}`)
+    } catch (err) {
+      console.error('Error al crear party', err)
+      setIsCreating(false)
+      setShowModal(false)
+    }
+  }
+
+  const getStatusBadge = (status: Party['status']) => {
+    switch (status) {
+      case 'active':   return <Badge variant="success">Activa</Badge>
+      case 'forming':  return <Badge variant="warning">Formando</Badge>
+      case 'waiting':  return <Badge variant="warning">En espera</Badge>
+      case 'closed':   return <Badge variant="neutral">Cerrada</Badge>
+    }
+  }
+
   return (
     <MobileLayout>
-      <div style={{ textAlign: 'center', margin: '60px 0' }}>
-        <h1 className="page-title">Tus Partys</h1>
-        <p className="empty-sub" style={{ marginBottom: '20px' }}>
-          Próximamente podrás ver y gestionar todas tus partys de estudio aquí.
-        </p>
-        <Badge variant="primary">En Construcción 🚧</Badge>
+      {/* Header */}
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '20px 0 8px' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+          <Button size="sm" variant="ghost" onClick={() => navigate('/dashboard')}>
+            ← Volver
+          </Button>
+          <h1 style={{ fontSize: '22px', fontWeight: 800 }}>Mis Parties</h1>
+        </div>
+        <Button size="sm" variant="primary" onClick={() => setShowModal(true)}>
+          + Crear
+        </Button>
       </div>
+
+      {/* Modal crear party */}
+      {showModal && (
+        <div style={{
+          position: 'fixed', inset: 0, zIndex: 200,
+          background: 'rgba(0,0,0,0.7)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          padding: '24px',
+        }}>
+          <div style={{
+            background: 'var(--bg-elevated)',
+            border: '1px solid var(--border)',
+            borderRadius: 'var(--radius-xl)',
+            padding: '28px',
+            width: '100%',
+            maxWidth: '380px',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '20px',
+          }}>
+            <h2 style={{ fontSize: '20px', fontWeight: 800 }}>🎮 Nueva Party</h2>
+
+            {subjects.length > 0 ? (
+              <div className="input-group">
+                <label className="input-label">Materia (opcional — por defecto tu primera materia)</label>
+                <select
+                  className="input input-select"
+                  value={selectedSubjectId}
+                  onChange={(e) => setSelectedSubjectId(e.target.value)}
+                >
+                  <option value="">— Auto (primera materia) —</option>
+                  {subjects.map((s) => (
+                    <option key={s.id} value={s.id}>{s.name}</option>
+                  ))}
+                </select>
+              </div>
+            ) : (
+              <p style={{ color: 'var(--text-secondary)', fontSize: '14px' }}>
+                ⚠️ No tenés materias inscriptas. Inscribite primero desde Explorar.
+              </p>
+            )}
+
+            <div style={{ display: 'flex', gap: '10px' }}>
+              <Button
+                variant="secondary"
+                className="flex-1"
+                onClick={() => setShowModal(false)}
+                disabled={isCreating}
+              >
+                Cancelar
+              </Button>
+              <Button
+                variant="primary"
+                className="flex-1"
+                onClick={handleCreate}
+                disabled={isCreating || subjects.length === 0}
+              >
+                {isCreating ? 'Creando…' : 'Crear Party'}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Lista */}
+      {isLoading ? (
+        <div className="center-spinner">
+          <Spinner size="lg" />
+        </div>
+      ) : parties.length === 0 ? (
+        <div className="empty-state">
+          <p className="empty-icon">👥</p>
+          <p className="empty-text">Aún no tenés parties</p>
+          <p className="empty-sub">Creá una nueva o buscá desde Matchmaking</p>
+          <div style={{ display: 'flex', gap: '10px', marginTop: '16px', justifyContent: 'center' }}>
+            <Button variant="secondary" onClick={() => navigate('/matchmaking')}>Buscar Party</Button>
+            <Button variant="primary" onClick={() => setShowModal(true)}>+ Crear</Button>
+          </div>
+        </div>
+      ) : (
+        <div className="party-list">
+          {parties.map(party => (
+            <div
+              key={party.id}
+              className="party-list-item"
+              onClick={() => navigate(`/party/${party.id}`)}
+            >
+              <div className="party-list-info">
+                <div className="party-list-name">
+                  {party.subject?.name ?? 'Party'}
+                </div>
+                <div className="party-list-meta">
+                  <span>👥 {party.members?.length || 0}/{party.maxMembers} miembros</span>
+                  <span>•</span>
+                  {getStatusBadge(party.status)}
+                </div>
+              </div>
+              <div className="party-list-arrow">›</div>
+            </div>
+          ))}
+        </div>
+      )}
     </MobileLayout>
   )
 }

--- a/frontend/src/services/partyService.ts
+++ b/frontend/src/services/partyService.ts
@@ -72,6 +72,11 @@ export const partyService = {
     return data
   },
 
+  async create(subjectId?: string, maxMembers = 4): Promise<Party> {
+    const { data } = await api.post<Party>('/parties', { subjectId, maxMembers })
+    return data
+  },
+
   async sendMessage(partyId: string, text: string): Promise<ChatMessage> {
     const { data } = await api.post<ChatMessage>(`/parties/${partyId}/chat`, {
       text,

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,4 +8,15 @@ export default defineConfig({
     react(),
     babel({ presets: [reactCompilerPreset()] })
   ],
+  server: {
+    host: '0.0.0.0',
+    port: 5173,
+    watch: {
+      // Necesario en Windows con Docker: el bind mount no propaga
+      // eventos inotify al contenedor Linux, así que usamos polling
+      usePolling: true,
+      interval: 1000,
+    },
+  },
 })
+


### PR DESCRIPTION


## Cambios

### Backend
- POST /parties: nuevo endpoint para crear una party propia (el usuario que la crea queda como leader). Si no se pasa subjectId, toma la primera materia inscripta del usuario.
- PartiesService.createForUser(): método que encapsula la lógica de creacion con transacción.
- CreatePartyDto: nuevo DTO con subjectId (optional) y maxMembers (optional, default 4).
- CORS hardcodeado a localhost:5173 para desarrollo local.

### Frontend
- PartiesPage: vista completamente funcional.
  - Lista las parties del usuario via GET /parties/mine.
  - Muestra nombre de materia, cantidad de miembros, badget de estado (forming/active/closed).
  - Botón + Crear en el header que abre un modal para seleccionar materia.
  - Al confirmar, llama a POST /parties y redirige automáticamente a la PartyRoom creada.
  - Empty state con accesos a Buscar Party y Crear Party.
- DashboardComponents: Quick Actions suma boton Mis Parties (rosa) → /parties.
- MatchPage: CREAR PARTY bar y EmptyState ahora navegan a /parties en lugar de /matchmaking.
- partyService: nuevo método create(subjectId?, maxMembers?).
- index.css: clases party-list, party-list-item, party-list-info, party-list-meta, party-list-arrow.
- ite.config.ts: usePolling habilitado para HMR en Docker sobre Windows.

Closes #22

## Resolves

Closes #

## What changed

- 

## How to test

1. 

## Checklist

- [ ] Linked issue is included
- [ ] Changes were tested
- [ ] Relevant docs were updated if needed
