### PR TITLE
feat/aniado-responsabilidades-al-host-de-party

### DIFF
--- a/backend/src/modules/parties/parties.controller.ts
+++ b/backend/src/modules/parties/parties.controller.ts
@@ -2,6 +2,7 @@ import {
   Controller,
   Get,
   Post,
+  Delete,
   Param,
   Body,
   UseGuards,
@@ -9,6 +10,8 @@ import {
   Query,
   Patch,
   BadRequestException,
+  ForbiddenException,
+  NotFoundException,
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
@@ -101,6 +104,48 @@ export class PartiesController {
       return await this.partiesService.joinParty(id, req.user.userId);
     } catch (error: any) {
       throw new BadRequestException(error.message + ' ||| STACK: ' + error.stack);
+    }
+  }
+
+  // ─── Acciones administrativas ─────────────────────────────────────────────
+
+  @Post(':id/leave')
+  @ApiOperation({ summary: 'Salir de la party (cualquier miembro)' })
+  async leaveParty(@Param('id') id: string, @Request() req: any) {
+    try {
+      await this.partiesService.leaveParty(id, req.user.userId);
+      return { message: 'Saliste de la party' };
+    } catch (error: any) {
+      if (error instanceof ForbiddenException || error instanceof NotFoundException) throw error;
+      throw new BadRequestException(error.message);
+    }
+  }
+
+  @Delete(':id/members/:userId')
+  @ApiOperation({ summary: 'Remover miembro de la party (solo líder)' })
+  async removeMember(
+    @Param('id') id: string,
+    @Param('userId') targetUserId: string,
+    @Request() req: any,
+  ) {
+    try {
+      await this.partiesService.removeMember(id, req.user.userId, targetUserId);
+      return { message: 'Miembro removido' };
+    } catch (error: any) {
+      if (error instanceof ForbiddenException || error instanceof NotFoundException) throw error;
+      throw new BadRequestException(error.message);
+    }
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: 'Cerrar la party (solo líder)' })
+  async closeParty(@Param('id') id: string, @Request() req: any) {
+    try {
+      await this.partiesService.closePartyAsHost(id, req.user.userId);
+      return { message: 'Party cerrada' };
+    } catch (error: any) {
+      if (error instanceof ForbiddenException || error instanceof NotFoundException) throw error;
+      throw new BadRequestException(error.message);
     }
   }
 }

--- a/backend/src/modules/parties/parties.service.ts
+++ b/backend/src/modules/parties/parties.service.ts
@@ -188,6 +188,82 @@ export class PartiesService {
     });
   }
 
+  /** Cierra la party — solo el líder puede hacerlo */
+  async closePartyAsHost(partyId: string, requesterId: string): Promise<void> {
+    const leader = await this.memberRepo.findOne({
+      where: { partyId, userId: requesterId, role: 'leader' },
+    });
+    if (!leader) throw new ForbiddenException('Solo el líder puede cerrar la party');
+    await this.closeParty(partyId);
+  }
+
+  /**
+   * Remueve a un miembro de la party.
+   * Reglas:
+   *  - El solicitante debe ser líder.
+   *  - El líder no puede removerse a sí mismo (debe usar leaveParty o closePartyAsHost).
+   */
+  async removeMember(
+    partyId: string,
+    requesterId: string,
+    targetUserId: string,
+  ): Promise<void> {
+    const requester = await this.memberRepo.findOne({
+      where: { partyId, userId: requesterId },
+    });
+    if (!requester || requester.role !== 'leader')
+      throw new ForbiddenException('Solo el líder puede remover miembros');
+    if (requesterId === targetUserId)
+      throw new BadRequestException(
+        'No podés removerte a vos mismo. Usá "Salir de la party" o "Cerrar party".',
+      );
+    const target = await this.memberRepo.findOne({
+      where: { partyId, userId: targetUserId },
+    });
+    if (!target) throw new NotFoundException('El miembro no pertenece a esta party');
+    await this.memberRepo.remove(target);
+  }
+
+  /**
+   * Sale de la party.
+   * Reglas:
+   *  - Si es member → solo se elimina su registro.
+   *  - Si es leader y hay otros miembros → promueve al miembro con joinedAt más antiguo.
+   *  - Si es leader y está solo → cierra la party.
+   */
+  async leaveParty(partyId: string, userId: string): Promise<void> {
+    return this.dataSource.transaction(async (em) => {
+      const memberRecord = await em.findOne(PartyMember, {
+        where: { partyId, userId },
+      });
+      if (!memberRecord) throw new NotFoundException('No sos miembro de esta party');
+
+      if (memberRecord.role !== 'leader') {
+        await em.remove(memberRecord);
+        return;
+      }
+
+      // Es el líder — buscar otros miembros
+      const others = await em.find(PartyMember, {
+        where: { partyId },
+        order: { joinedAt: 'ASC' },
+      });
+      const rest = others.filter((m) => m.userId !== userId);
+
+      if (rest.length === 0) {
+        // Estaba solo → cerrar party
+        await em.remove(memberRecord);
+        await em.update(Party, partyId, { status: 'closed', closedAt: new Date() });
+        return;
+      }
+
+      // Promover al miembro más antiguo y eliminar al líder saliente
+      const newLeader = rest[0];
+      await em.update(PartyMember, { id: newLeader.id }, { role: 'leader' });
+      await em.remove(memberRecord);
+    });
+  }
+
   async updateVisibility(partyId: string, userId: string, isPrivate: boolean): Promise<void> {
     const leader = await this.memberRepo.findOne({
       where: { partyId, userId, role: 'leader' },

--- a/frontend/src/components/PartyComponents.tsx
+++ b/frontend/src/components/PartyComponents.tsx
@@ -117,10 +117,14 @@ interface MemberListProps {
   isPrivate: boolean
   currentUserId: string
   onVisibilityChange: (isPrivate: boolean) => void
+  onLeave: () => void
+  onRemoveMember: (targetUserId: string) => void
+  onCloseParty: () => void
 }
 
-export function MemberList({ members, partyId, isPrivate, currentUserId, onVisibilityChange }: MemberListProps) {
+export function MemberList({ members, partyId, isPrivate, currentUserId, onVisibilityChange, onLeave, onRemoveMember, onCloseParty }: MemberListProps) {
   const [showInvite, setShowInvite] = useState(false)
+  const [confirmClose, setConfirmClose] = useState(false)
   const isLeader = members.some((m) => m.userId === currentUserId && m.role === 'leader')
 
   return (
@@ -164,10 +168,55 @@ export function MemberList({ members, partyId, isPrivate, currentUserId, onVisib
             <div className="member-stats">
               <span className="member-xp">⚡{m.user.stats?.xp ?? 0}</span>
               {m.role === 'leader' && <span className="member-leader">👑</span>}
+              {isLeader && m.userId !== currentUserId && (
+                <button
+                  className="member-remove-btn"
+                  title="Remover miembro"
+                  onClick={() => onRemoveMember(m.userId)}
+                >
+                  ✕
+                </button>
+              )}
             </div>
           </div>
         ))}
       </div>
+
+      {/* ─ Acciones del miembro ─ */}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', marginTop: '16px' }}>
+        <button
+          className="party-leave-btn"
+          onClick={onLeave}
+        >
+          🚪 Salir de la party
+        </button>
+
+        {isLeader && (
+          confirmClose ? (
+            <div className="party-close-confirm">
+              <p style={{ fontSize: '13px', color: 'var(--text-secondary)', margin: 0 }}>
+                ¿Cerrás la party para todos?
+              </p>
+              <div style={{ display: 'flex', gap: '8px' }}>
+                <button className="party-close-confirm-btn" onClick={onCloseParty}>
+                  Sí, cerrar
+                </button>
+                <button className="party-close-cancel-btn" onClick={() => setConfirmClose(false)}>
+                  Cancelar
+                </button>
+              </div>
+            </div>
+          ) : (
+            <button
+              className="party-close-btn"
+              onClick={() => setConfirmClose(true)}
+            >
+              🔒 Cerrar party
+            </button>
+          )
+        )}
+      </div>
+
       {showInvite && (
         <InviteSheet partyId={partyId} onClose={() => setShowInvite(false)} />
       )}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -511,6 +511,82 @@ input, textarea, select { font-family: inherit; }
 .member-stats { display: flex; align-items: center; gap: 8px; }
 .member-xp { font-size: 13px; font-weight: 700; color: var(--accent-light); }
 .member-leader { font-size: 16px; }
+.member-remove-btn {
+  width: 26px; height: 26px;
+  border-radius: var(--radius-full);
+  border: 1px solid rgba(239,68,68,0.35);
+  background: rgba(239,68,68,0.08);
+  color: var(--red);
+  font-size: 13px;
+  display: flex; align-items: center; justify-content: center;
+  cursor: pointer;
+  transition: all 0.15s;
+  flex-shrink: 0;
+}
+.member-remove-btn:hover { background: rgba(239,68,68,0.2); transform: scale(1.1); }
+
+/* ─── Admin action buttons ───────────────────────────────────────────────── */
+.party-leave-btn {
+  display: flex; align-items: center; justify-content: center;
+  gap: 8px;
+  padding: 12px 16px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  background: var(--bg-surface);
+  color: var(--text-secondary);
+  font-size: 14px; font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+  margin: 0 16px;
+}
+.party-leave-btn:hover { border-color: rgba(239,68,68,0.4); color: var(--red); background: rgba(239,68,68,0.06); }
+
+.party-close-btn {
+  display: flex; align-items: center; justify-content: center;
+  gap: 8px;
+  padding: 11px 16px;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(239,68,68,0.3);
+  background: rgba(239,68,68,0.07);
+  color: var(--red);
+  font-size: 14px; font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+  margin: 0 16px;
+}
+.party-close-btn:hover { background: rgba(239,68,68,0.15); border-color: rgba(239,68,68,0.6); }
+
+.party-close-confirm {
+  display: flex; flex-direction: column; gap: 10px;
+  padding: 14px 16px;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(239,68,68,0.3);
+  background: rgba(239,68,68,0.07);
+  margin: 0 16px;
+  animation: fadeIn 0.15s ease;
+}
+.party-close-confirm-btn {
+  flex: 1; padding: 9px 14px;
+  border-radius: var(--radius-md);
+  border: none;
+  background: var(--red);
+  color: #fff;
+  font-size: 13px; font-weight: 700;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+.party-close-confirm-btn:hover { opacity: 0.85; }
+.party-close-cancel-btn {
+  flex: 1; padding: 9px 14px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+  font-size: 13px; font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.party-close-cancel-btn:hover { background: var(--bg-input); }
 
 /* ─── Invite ─────────────────────────────────────────────────────────────── */
 .invite-btn {

--- a/frontend/src/pages/PartyRoomPage.tsx
+++ b/frontend/src/pages/PartyRoomPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { useParams } from 'react-router-dom'
+import { useParams, useNavigate } from 'react-router-dom'
 import { MobileLayout } from '../components/Layouts'
 import {
   PartyHeader,
@@ -18,6 +18,7 @@ type ActiveTab = 'quests' | 'chat' | 'members'
 
 const PartyRoomPage = () => {
   const { partyId } = useParams<{ partyId: string }>()
+  const navigate = useNavigate()
   const [activeTab, setActiveTab] = useState<ActiveTab>('quests')
   const { party, setParty, messages, sendMessage, isLoading, currentUserId } = useParty(partyId ?? '')
   const { quests, uploadNote, isGenerating } = useQuests(partyId ?? '')
@@ -27,6 +28,39 @@ const PartyRoomPage = () => {
     { id: 'chat', label: '💬 Chat' },
     { id: 'members', label: '👥 Miembros' },
   ]
+
+  const handleLeave = async () => {
+    if (!party) return
+    try {
+      await partyService.leaveParty(party.id)
+      navigate('/parties')
+    } catch (err) {
+      console.error('Error al salir de la party:', err)
+    }
+  }
+
+  const handleRemoveMember = async (targetUserId: string) => {
+    if (!party) return
+    try {
+      await partyService.removeMember(party.id, targetUserId)
+      setParty({
+        ...party,
+        members: party.members.filter((m) => m.userId !== targetUserId),
+      })
+    } catch (err) {
+      console.error('Error al remover miembro:', err)
+    }
+  }
+
+  const handleCloseParty = async () => {
+    if (!party) return
+    try {
+      await partyService.closeParty(party.id)
+      navigate('/parties')
+    } catch (err) {
+      console.error('Error al cerrar la party:', err)
+    }
+  }
 
   if (isLoading) {
     return (
@@ -71,6 +105,9 @@ const PartyRoomPage = () => {
               setParty({ ...party, isPrivate })
             }).catch(console.error)
           }}
+          onLeave={handleLeave}
+          onRemoveMember={handleRemoveMember}
+          onCloseParty={handleCloseParty}
         />
       )}
     </MobileLayout>

--- a/frontend/src/services/partyService.ts
+++ b/frontend/src/services/partyService.ts
@@ -92,6 +92,18 @@ export const partyService = {
     return data
   },
 
+  async leaveParty(partyId: string): Promise<void> {
+    await api.post(`/parties/${partyId}/leave`)
+  },
+
+  async removeMember(partyId: string, targetUserId: string): Promise<void> {
+    await api.delete(`/parties/${partyId}/members/${targetUserId}`)
+  },
+
+  async closeParty(partyId: string): Promise<void> {
+    await api.delete(`/parties/${partyId}`)
+  },
+
   async sendMessage(partyId: string, text: string): Promise<ChatMessage> {
     const { data } = await api.post<ChatMessage>(`/parties/${partyId}/chat`, {
       text,


### PR DESCRIPTION
## Descripcion

Se añadieron controles de administración básicos para el host (líder) de la party, permitiéndole gestionarla sin afectar a los miembros cuando no corresponde, junto con la posibilidad de salir para cualquier miembro.

**Backend (`PartiesService` & `PartiesController`)**:
- Nuevos endpoints para abandonar la party (`POST /parties/:id/leave`), remover miembros (`DELETE /parties/:id/members/:userId`) y cerrar la party (`DELETE /parties/:id`).
- Reglas de negocio implementadas:
  - El líder puede expulsar miembros, pero no a sí mismo.
  - El líder puede cerrar la party en su totalidad.
  - Al salir de la party, si es el líder y existen otros miembros, **se promueve al miembro más antiguo** automáticamente. Si está solo, se cierra.
  - Cualquier otro miembro puede salir de forma individual.
- Manejo de excepciones por permisos (`ForbiddenException` y `BadRequestException`).

**Frontend**:
- Nuevos métodos en `partyService` para interactuar con la nueva API.
- Componente `MemberList` extendido:
  - **Líder**: ve un botón `✕` (remover) al lado de cada miembro.
  - **Todos**: ven un botón `🚪 Salir de la party`.
  - **Líder**: ve un botón `🔒 Cerrar party` (exclusivo) con validación tipo confirmación inline (¿Estás seguro?).
- UI en `PartyRoomPage` conectada a los servicios, manejando el redireccionamiento optimista tras salir o cerrar la sala.
- Estilos CSS propios de la temática añadidos en `index.css`.

## Resolves

Closes #49 