### PR TITLE
feat(parties): mostrar miembros y estado de presencia en Party Room

### DIFF
--- a/frontend/src/components/PartyComponents.tsx
+++ b/frontend/src/components/PartyComponents.tsx
@@ -154,20 +154,39 @@ export function MemberList({ members, partyId, isPrivate, currentUserId, onVisib
         )}
 
         {members.map((m) => (
-          <div key={m.id} className="member-item">
-            <div className="member-avatar">
+          <div
+            key={m.id}
+            className={`member-item${m.role === 'leader' ? ' member-item-leader' : ''}`}
+          >
+            {/* Avatar con indicador de presencia superpuesto */}
+            <div className="member-avatar" style={{ position: 'relative' }}>
               {m.user.avatarUrl
                 ? <img src={m.user.avatarUrl} alt={m.user.displayName} className="avatar-sm" />
                 : <div className="avatar-placeholder-sm">{m.user.displayName[0]}</div>
               }
+              <span
+                className={`presence-dot presence-dot-${m.isOnline ? 'online' : 'offline'}`}
+                title={m.isOnline ? 'En línea' : 'Desconectado'}
+              />
             </div>
+
             <div className="member-info">
-              <p className="member-name">{m.user.displayName}</p>
+              <p className="member-name">
+                {m.user.displayName}
+                {/* Etiqueta de líder junto al nombre para que sea inmediatamente visible */}
+                {m.role === 'leader' && (
+                  <span className="member-leader-badge">👑 Líder</span>
+                )}
+              </p>
               <p className="member-username">@{m.user.username}</p>
             </div>
+
             <div className="member-stats">
               <span className="member-xp">⚡{m.user.stats?.xp ?? 0}</span>
-              {m.role === 'leader' && <span className="member-leader">👑</span>}
+              {/* Texto de estado de presencia */}
+              <span className={`member-presence-label member-presence-label-${m.isOnline ? 'online' : 'offline'}`}>
+                {m.isOnline ? 'En línea' : 'Desconectado'}
+              </span>
               {isLeader && m.userId !== currentUserId && (
                 <button
                   className="member-remove-btn"

--- a/frontend/src/hooks/useParty.ts
+++ b/frontend/src/hooks/useParty.ts
@@ -30,14 +30,29 @@ export function useParty(partyId: string) {
     })
 
     socket.emit('party:join', { partyId })
+
     socket.on('chat:message', (msg: ChatMessage) => {
       setMessages((prev) => [...prev, msg])
+    })
+
+    // Actualiza el estado de presencia de un miembro sin recargar toda la party
+    socket.on('party:member-online', ({ userId, isOnline }: { userId: string; isOnline: boolean }) => {
+      setParty((prev) => {
+        if (!prev) return prev
+        return {
+          ...prev,
+          members: prev.members.map((m) =>
+            m.userId === userId ? { ...m, isOnline } : m
+          ),
+        }
+      })
     })
 
     return () => {
       cancelled = true
       socket.emit('party:leave', partyId)
       socket.off('chat:message')
+      socket.off('party:member-online')
     }
   }, [partyId, socket])
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -790,7 +790,39 @@ input, textarea, select { font-family: inherit; }
 .member-username { font-size: 12px; color: var(--text-muted); }
 .member-stats { display: flex; align-items: center; gap: 8px; }
 .member-xp { font-size: 13px; font-weight: 700; color: var(--accent-light); }
-.member-leader { font-size: 16px; }
+/* Filas de miembro: el líder tiene un borde izquierdo dorado para distinguirse */
+.member-item-leader { border-left: 3px solid var(--accent-light); }
+
+/* Punto de presencia superpuesto sobre el avatar */
+.presence-dot {
+  position: absolute;
+  bottom: 1px;
+  right: 1px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  border: 2px solid var(--bg-base, #0f0f17);
+}
+.presence-dot-online  { background: #22c55e; }
+.presence-dot-offline { background: #6b7280; }
+
+/* Etiqueta de texto de presencia dentro de .member-stats */
+.member-presence-label { font-size: 11px; font-weight: 600; }
+.member-presence-label-online  { color: #22c55e; }
+.member-presence-label-offline { color: var(--text-muted); }
+
+/* Etiqueta de "Líder" junto al nombre */
+.member-leader-badge {
+  margin-left: 6px;
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--accent-light);
+  background: rgba(var(--accent-rgb, 139,92,246), 0.15);
+  padding: 1px 6px;
+  border-radius: var(--radius-full);
+  vertical-align: middle;
+}
+
 .member-remove-btn {
   width: 26px; height: 26px;
   border-radius: var(--radius-full);


### PR DESCRIPTION
Cierra #47

## Que cambia?

Implementa la visualizacion de miembros y su estado de presencia dentro de la Party Room, cumpliendo todos los criterios de aceptacion del issue.

## Cambios realizados

### frontend/src/hooks/useParty.ts
- Se suscribe al evento WebSocket party:member-online que ya emitia el backend al entrar/salir de la sala.
- Al recibirlo, actualiza unicamente el campo isOnline del miembro correspondiente en el estado local, sin recargar toda la party.
- Se limpia el listener en el cleanup del efecto para evitar registros duplicados.

### frontend/src/components/PartyComponents.tsx
- Cada fila de miembro muestra un punto de color superpuesto sobre el avatar indicando su presencia.
- Se agrega una etiqueta de texto En linea / Desconectado dentro de member-stats.
- El lider se distingue visualmente con un badge 👑 Lider inline junto al nombre y un borde izquierdo dorado en la fila.

### frontend/src/index.css
- Nuevas clases: member-item-leader, presence-dot, presence-dot-online/offline, member-leader-badge, member-presence-label.

## Criterios de aceptacion

| Criterio | Estado |
|---|---|
| La Party Room muestra listado de miembros | OK |
| Cada miembro tiene estado visible online/offline | OK |
| El host/admin se distingue visualmente | OK |
| Los cambios de presencia se reflejan en tiempo real o al refrescar | OK |

## Notas

El estado En linea refleja que el usuario tiene la Party Room abierta activamente. Al navegar fuera o cerrar la pestana, el socket emite party:leave y los demas miembros ven el cambio en tiempo real.