### PR TITLE
partyRoom + actividad de salas

### DIFF
--- a/backend/src/gateways/matchmaking/matchmaking.gateway.ts
+++ b/backend/src/gateways/matchmaking/matchmaking.gateway.ts
@@ -11,6 +11,7 @@ import { Server, Socket } from 'socket.io';
 import { Logger } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { JwtService } from '@nestjs/jwt';
+import { OnEvent } from '@nestjs/event-emitter';
 import { v4 as uuid } from 'uuid';
 import { MatchmakingService, QueueCandidate } from './matchmaking.service';
 import { PartiesService } from '../../modules/parties/parties.service';
@@ -250,5 +251,15 @@ export class MatchmakingGateway
         },
       );
     }
+  }
+
+  // ─── Activity Events ──────────────────────────────────────────────────────────
+
+  @OnEvent('party.activity')
+  handlePartyActivity(payload: { partyId: string; activity: any }) {
+    this.logger.debug(`Activity en party ${payload.partyId}: ${payload.activity.type}`);
+    this.server.to(payload.partyId).emit('party:activity', {
+      activity: payload.activity,
+    });
   }
 }

--- a/backend/src/modules/parties/parties.controller.ts
+++ b/backend/src/modules/parties/parties.controller.ts
@@ -78,6 +78,12 @@ export class PartiesController {
     return this.partiesService.getChatHistory(id, +limit);
   }
 
+  @Get(':id/activity')
+  @ApiOperation({ summary: 'Historial de actividades de la party' })
+  getActivity(@Param('id') id: string, @Query('limit') limit = 50) {
+    return this.partiesService.getActivityHistory(id, +limit);
+  }
+
   @Patch(':id/visibility')
   @ApiOperation({ summary: 'Cambiar visibilidad de la party (solo líder)' })
   updateVisibility(

--- a/backend/src/modules/parties/parties.module.ts
+++ b/backend/src/modules/parties/parties.module.ts
@@ -3,12 +3,13 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Party } from './party.entity';
 import { PartyMember } from './party-member.entity';
 import { ChatMessage } from './chat-message.entity';
+import { PartyActivity } from './party-activity.entity';
 import { PartiesService } from './parties.service';
 import { PartiesController } from './parties.controller';
 import { User } from '../users/user.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Party, PartyMember, ChatMessage, User])],
+  imports: [TypeOrmModule.forFeature([Party, PartyMember, ChatMessage, PartyActivity, User])],
   controllers: [PartiesController],
   providers: [PartiesService],
   exports: [PartiesService, TypeOrmModule],

--- a/backend/src/modules/parties/parties.service.ts
+++ b/backend/src/modules/parties/parties.service.ts
@@ -7,10 +7,12 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, DataSource, MoreThan } from 'typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { v4 as uuid } from 'uuid';
 import { Party } from './party.entity';
 import { PartyMember } from './party-member.entity';
 import { ChatMessage } from './chat-message.entity';
+import { PartyActivity, ActivityType } from './party-activity.entity';
 import { User } from '../users/user.entity';
 
 @Injectable()
@@ -22,9 +24,12 @@ export class PartiesService {
     private readonly memberRepo: Repository<PartyMember>,
     @InjectRepository(ChatMessage)
     private readonly chatRepo: Repository<ChatMessage>,
+    @InjectRepository(PartyActivity)
+    private readonly activityRepo: Repository<PartyActivity>,
     @InjectRepository(User)
     private readonly userRepo: Repository<User>,
     private readonly dataSource: DataSource,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   // ─── Invite Link (≥PostgreSQL, sin Redis) ────────────────────────────────────
@@ -129,6 +134,15 @@ export class PartiesService {
         relations: ['subject', 'members', 'members.user'],
       });
       if (!result) throw new NotFoundException('Error al crear la party');
+
+      // Log que se creó la party después de la transacción
+      await this.logActivity(
+        party.id,
+        'member_joined',
+        userId,
+        'Creó la party (como líder)',
+      );
+
       return result;
     });
   }
@@ -186,6 +200,13 @@ export class PartiesService {
       status: 'closed',
       closedAt: new Date(),
     });
+    await this.logActivity(
+      partyId,
+      'party_status_changed',
+      undefined,
+      'Party cerrada',
+      { oldStatus: 'active', newStatus: 'closed' },
+    );
   }
 
   /** Cierra la party — solo el líder puede hacerlo */
@@ -222,6 +243,14 @@ export class PartiesService {
     });
     if (!target) throw new NotFoundException('El miembro no pertenece a esta party');
     await this.memberRepo.remove(target);
+
+    await this.logActivity(
+      partyId,
+      'member_removed',
+      requesterId,
+      `Removió a un miembro`,
+      { targetUserId },
+    );
   }
 
   /**
@@ -240,6 +269,12 @@ export class PartiesService {
 
       if (memberRecord.role !== 'leader') {
         await em.remove(memberRecord);
+        await this.logActivity(
+          partyId,
+          'member_left',
+          userId,
+          'Salió de la party',
+        );
         return;
       }
 
@@ -254,6 +289,13 @@ export class PartiesService {
         // Estaba solo → cerrar party
         await em.remove(memberRecord);
         await em.update(Party, partyId, { status: 'closed', closedAt: new Date() });
+        await this.logActivity(
+          partyId,
+          'party_status_changed',
+          userId,
+          'Party cerrada (líder se fue y no había otros miembros)',
+          { oldStatus: 'active', newStatus: 'closed' },
+        );
         return;
       }
 
@@ -261,6 +303,19 @@ export class PartiesService {
       const newLeader = rest[0];
       await em.update(PartyMember, { id: newLeader.id }, { role: 'leader' });
       await em.remove(memberRecord);
+
+      await this.logActivity(
+        partyId,
+        'member_left',
+        userId,
+        'Salió de la party (era líder)',
+      );
+      await this.logActivity(
+        partyId,
+        'member_promoted',
+        newLeader.userId,
+        `Fue promovido a líder`,
+      );
     });
   }
 
@@ -269,7 +324,21 @@ export class PartiesService {
       where: { partyId, userId, role: 'leader' },
     });
     if (!leader) throw new ForbiddenException('Solo el líder puede cambiar la visibilidad de la party');
+
+    const currentParty = await this.partyRepo.findOne({ where: { id: partyId } });
+    const oldVisibility = currentParty?.isPrivate ?? false;
+
     await this.partyRepo.update(partyId, { isPrivate });
+
+    if (oldVisibility !== isPrivate) {
+      await this.logActivity(
+        partyId,
+        'party_visibility_changed',
+        userId,
+        `Cambió la visibilidad de la party a ${isPrivate ? 'privada' : 'pública'}`,
+        { oldVisibility, newVisibility: isPrivate },
+      );
+    }
   }
 
   async addChatMessage(
@@ -290,6 +359,48 @@ export class PartiesService {
       take: limit,
     });
     return msgs.reverse();
+  }
+
+  // ─── Activity Logging ──────────────────────────────────────────────────────────
+
+  /**
+   * Registra una actividad en la party (miembro se unió, quest completado, etc)
+   */
+  async logActivity(
+    partyId: string,
+    type: ActivityType,
+    userId?: string,
+    description?: string,
+    metadata?: any,
+  ): Promise<PartyActivity> {
+    const activity = this.activityRepo.create({
+      partyId,
+      type,
+      userId,
+      description,
+      metadata,
+    });
+    const saved = await this.activityRepo.save(activity);
+
+    // Emitir evento para que el gateway lo transmita via WebSocket
+    this.eventEmitter.emit('party.activity', {
+      partyId,
+      activity: saved,
+    });
+
+    return saved;
+  }
+
+  /**
+   * Obtiene el historial de actividades de una party
+   */
+  async getActivityHistory(partyId: string, limit = 50): Promise<PartyActivity[]> {
+    return this.activityRepo.find({
+      where: { partyId },
+      relations: ['user'],
+      order: { createdAt: 'DESC' },
+      take: limit,
+    });
   }
 
   /**
@@ -373,9 +484,11 @@ export class PartiesService {
       });
       await em.save(member);
 
+      let statusChanged = false;
       // Si la party se llenó, pasarla a active
       if (party.members.length + 1 >= party.maxMembers) {
         await em.update(Party, partyId, { status: 'active' });
+        statusChanged = true;
       }
 
       const updated = await em.findOne(Party, {
@@ -383,6 +496,25 @@ export class PartiesService {
         relations: ['subject', 'members', 'members.user', 'quests'],
       });
       if (!updated) throw new NotFoundException('Party no encontrada tras unirse');
+
+      // Log activity después de la transacción
+      await this.logActivity(
+        partyId,
+        'member_joined',
+        userId,
+        `Se unió a la party`,
+      );
+
+      if (statusChanged) {
+        await this.logActivity(
+          partyId,
+          'party_status_changed',
+          undefined,
+          'Party se llenó y pasó a activa',
+          { oldStatus: 'forming', newStatus: 'active' },
+        );
+      }
+
       return updated;
     });
   }

--- a/backend/src/modules/parties/party-activity.entity.ts
+++ b/backend/src/modules/parties/party-activity.entity.ts
@@ -1,0 +1,78 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+} from 'typeorm';
+import { Party } from './party.entity';
+import { User } from '../users/user.entity';
+
+export type ActivityType =
+  | 'member_joined'      // Un miembro se unió
+  | 'member_left'        // Un miembro se fue
+  | 'member_removed'     // Un miembro fue removido por líder
+  | 'quest_created'      // Se subió una nota (se generó quest)
+  | 'quest_started'      // Alguien empezó un quest
+  | 'quest_completed'    // Un quest fue completado
+  | 'party_status_changed'  // La party cambió de estado
+  | 'party_visibility_changed'  // La party cambió de visibilidad
+  | 'member_promoted';   // Un miembro fue promovido a líder
+
+@Entity('party_activities')
+@Index(['partyId', 'createdAt'])
+@Index(['userId'])
+export class PartyActivity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'party_id' })
+  partyId: string;
+
+  @Column({ name: 'user_id', nullable: true })
+  userId?: string;
+
+  @Column({
+    type: 'enum',
+    enum: [
+      'member_joined',
+      'member_left',
+      'member_removed',
+      'quest_created',
+      'quest_started',
+      'quest_completed',
+      'party_status_changed',
+      'party_visibility_changed',
+      'member_promoted',
+    ],
+  })
+  type: ActivityType;
+
+  @Column({ type: 'text', nullable: true })
+  description: string;
+
+  @Column({ type: 'jsonb', nullable: true })
+  metadata?: {
+    questId?: string;
+    questTitle?: string;
+    targetUserId?: string;
+    targetUserName?: string;
+    oldStatus?: string;
+    newStatus?: string;
+    oldVisibility?: boolean;
+    newVisibility?: boolean;
+  };
+
+  @ManyToOne(() => Party, (p) => p.activities, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'party_id' })
+  party: Party;
+
+  @ManyToOne(() => User, { onDelete: 'SET NULL', nullable: true })
+  @JoinColumn({ name: 'user_id' })
+  user: User;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+  createdAt: Date;
+}

--- a/backend/src/modules/parties/party.entity.ts
+++ b/backend/src/modules/parties/party.entity.ts
@@ -13,6 +13,7 @@ import { Subject } from '../subjects/subject.entity';
 import { PartyMember } from './party-member.entity';
 import { ChatMessage } from './chat-message.entity';
 import { Quest } from '../quests/quest.entity';
+import { PartyActivity } from './party-activity.entity';
 
 export type PartyStatus = 'forming' | 'active' | 'closed';
 
@@ -51,6 +52,9 @@ export class Party {
 
   @OneToMany(() => Quest, (q) => q.party)
   quests: Quest[];
+
+  @OneToMany(() => PartyActivity, (pa) => pa.party, { cascade: true })
+  activities: PartyActivity[];
 
   @Column({
     name: 'closed_at',

--- a/frontend/src/components/PartyComponents.tsx
+++ b/frontend/src/components/PartyComponents.tsx
@@ -387,3 +387,88 @@ export function QuestCard({ quest }: { quest: Quest }) {
     </div>
   )
 }
+
+// ─── ActivityFeed ────────────────────────────────────────────────────────────
+export interface Activity {
+  id: string
+  type: string
+  description: string
+  user?: { id: string; displayName: string; avatarUrl?: string }
+  createdAt: string
+  metadata?: any
+}
+
+interface ActivityFeedProps {
+  activities: Activity[]
+  isLoading?: boolean
+}
+
+const getActivityEmoji = (type: string): string => {
+  const emojis: Record<string, string> = {
+    member_joined: '👋',
+    member_left: '👋',
+    member_removed: '🚫',
+    quest_created: '✨',
+    quest_started: '▶️',
+    quest_completed: '✅',
+    party_status_changed: '🔄',
+    party_visibility_changed: '🔒',
+    member_promoted: '👑',
+  }
+  return emojis[type] || '📌'
+}
+
+const getActivityColor = (type: string): string => {
+  const colors: Record<string, string> = {
+    member_joined: '#4ade80',
+    member_left: '#64748b',
+    member_removed: '#ef4444',
+    quest_created: '#06b6d4',
+    quest_started: '#f59e0b',
+    quest_completed: '#10b981',
+    party_status_changed: '#8b5cf6',
+    party_visibility_changed: '#ec4899',
+    member_promoted: '#f59e0b',
+  }
+  return colors[type] || '#94a3b8'
+}
+
+export function ActivityFeed({ activities, isLoading }: ActivityFeedProps) {
+  if (isLoading) {
+    return (
+      <div style={{ padding: '16px', textAlign: 'center' }}>
+        <Spinner size="sm" />
+      </div>
+    )
+  }
+
+  if (activities.length === 0) {
+    return (
+      <div style={{ padding: '20px', textAlign: 'center', color: 'var(--text-secondary)', fontSize: '14px' }}>
+        <p>Sin actividad todavía</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="activity-feed">
+      {activities.map((activity) => (
+        <div key={activity.id} className="activity-item">
+          <div className="activity-dot" style={{ backgroundColor: getActivityColor(activity.type) }} />
+          <div className="activity-content">
+            <div className="activity-header">
+              <span className="activity-emoji">{getActivityEmoji(activity.type)}</span>
+              {activity.user && (
+                <span className="activity-user">{activity.user.displayName}</span>
+              )}
+            </div>
+            <p className="activity-description">{activity.description}</p>
+            <span className="activity-time">
+              {new Date(activity.createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+            </span>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/hooks/useActivity.ts
+++ b/frontend/src/hooks/useActivity.ts
@@ -1,0 +1,40 @@
+import { useState, useEffect } from 'react'
+import { partyService, type Activity } from '../services/partyService'
+import { useSocket } from './useSocket'
+
+export function useActivity(partyId: string) {
+  const { socket } = useSocket()
+  const [activities, setActivities] = useState<Activity[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+
+  useEffect(() => {
+    if (!partyId) return
+    let cancelled = false
+
+    setIsLoading(true)
+    partyService.getActivity(partyId).then((acts) => {
+      if (!cancelled) {
+        setActivities(acts)
+      }
+    }).catch((err) => {
+      console.error('Error loading activities:', err)
+      if (!cancelled) setActivities([])
+    }).finally(() => {
+      if (!cancelled) setIsLoading(false)
+    })
+
+    // Escuchar nuevas actividades via WebSocket
+    socket.on('party:activity', (payload: { activity: Activity }) => {
+      if (!cancelled) {
+        setActivities((prev) => [payload.activity, ...prev])
+      }
+    })
+
+    return () => {
+      cancelled = true
+      socket.off('party:activity')
+    }
+  }, [partyId, socket])
+
+  return { activities, isLoading }
+}

--- a/frontend/src/pages/PartyRoomPage.tsx
+++ b/frontend/src/pages/PartyRoomPage.tsx
@@ -8,13 +8,15 @@ import {
   MemberList,
   UploadNoteCard,
   QuestCard,
+  ActivityFeed,
 } from '../components/PartyComponents'
 import { Spinner } from '../components/UI'
 import { useParty } from '../hooks/useParty'
 import { useQuests } from '../hooks/useQuests'
+import { useActivity } from '../hooks/useActivity'
 import { partyService } from '../services/partyService'
 
-type ActiveTab = 'quests' | 'chat' | 'members'
+type ActiveTab = 'quests' | 'chat' | 'members' | 'activity'
 
 const PartyRoomPage = () => {
   const { partyId } = useParams<{ partyId: string }>()
@@ -22,11 +24,13 @@ const PartyRoomPage = () => {
   const [activeTab, setActiveTab] = useState<ActiveTab>('quests')
   const { party, setParty, messages, sendMessage, isLoading, currentUserId } = useParty(partyId ?? '')
   const { quests, uploadNote, isGenerating } = useQuests(partyId ?? '')
+  const { activities, isLoading: activityLoading } = useActivity(partyId ?? '')
 
   const tabs: Array<{ id: ActiveTab; label: string }> = [
     { id: 'quests', label: '⚡ Quests' },
     { id: 'chat', label: '💬 Chat' },
     { id: 'members', label: '👥 Miembros' },
+    { id: 'activity', label: '📊 Historial' },
   ]
 
   const handleLeave = async () => {
@@ -109,6 +113,12 @@ const PartyRoomPage = () => {
           onRemoveMember={handleRemoveMember}
           onCloseParty={handleCloseParty}
         />
+      )}
+
+      {activeTab === 'activity' && (
+        <div className="tab-content">
+          <ActivityFeed activities={activities} isLoading={activityLoading} />
+        </div>
       )}
     </MobileLayout>
   )

--- a/frontend/src/services/partyService.ts
+++ b/frontend/src/services/partyService.ts
@@ -9,6 +9,15 @@ export interface ChatMessage {
   createdAt: string
 }
 
+export interface Activity {
+  id: string
+  type: string
+  description: string
+  user?: Pick<User, 'id' | 'username' | 'displayName' | 'avatarUrl'>
+  createdAt: string
+  metadata?: any
+}
+
 export interface PartyMember {
   id: string
   userId: string
@@ -107,6 +116,13 @@ export const partyService = {
   async sendMessage(partyId: string, text: string): Promise<ChatMessage> {
     const { data } = await api.post<ChatMessage>(`/parties/${partyId}/chat`, {
       text,
+    })
+    return data
+  },
+
+  async getActivity(partyId: string, limit = 50): Promise<Activity[]> {
+    const { data } = await api.get<Activity[]>(`/parties/${partyId}/activity`, {
+      params: { limit },
     })
     return data
   },


### PR DESCRIPTION
## Resolves
Closes #45 
feat: Agregar feed de actividad a la Party Room

- Nueva entidad `PartyActivity` para rastrear eventos de la party (uniones de miembros, creación de quests, cambios de estado)
- Logging de actividades integrado en métodos del servicio de parties
- Endpoint `GET /parties/:id/activity` para obtener historial
- Actualizaciones de actividad en tiempo real via WebSocket
- Componente `ActivityFeed` y hook `useActivity` en frontend
- Nueva pestaña "Historial" en Party Room mostrando timeline de actividades

Esto consolida la party como centro colaborativo de estudio, proporcionando visibilidad sobre las actividades y progreso del grupo.