### PR TITLE
feat/feat implementacion de logros, roles y actualizacion seed

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -21,6 +21,7 @@ import { PartiesModule } from './modules/parties/parties.module';
 import { QuestsModule } from './modules/quests/quests.module';
 import { AiModule } from './modules/ai/ai.module';
 import { SkillTreeModule } from './modules/skill-tree/skill-tree.module';
+import { AchievementsModule } from './modules/achievements/achievements.module';
 import { MatchmakingModule } from './gateways/matchmaking/matchmaking.module';
 
 @Module({
@@ -85,6 +86,7 @@ import { MatchmakingModule } from './gateways/matchmaking/matchmaking.module';
     QuestsModule,
     AiModule,
     SkillTreeModule,
+    AchievementsModule,
     MatchmakingModule,
   ],
 })

--- a/backend/src/common/roles.ts
+++ b/backend/src/common/roles.ts
@@ -1,0 +1,26 @@
+import { SetMetadata, Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+
+export enum Role {
+  USER = 'USER',
+  ADMIN = 'ADMIN',
+}
+
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: Role[]) => SetMetadata(ROLES_KEY, roles);
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private readonly reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<Role[]>(ROLES_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (!requiredRoles?.length) return true;
+
+    const { user } = context.switchToHttp().getRequest();
+    return requiredRoles.includes(user?.role);
+  }
+}

--- a/backend/src/database/seeds/seed.ts
+++ b/backend/src/database/seeds/seed.ts
@@ -35,6 +35,7 @@ import { QuizQuestion } from '../../modules/quests/quiz-question.entity';
 import { QuizOption } from '../../modules/quests/quiz-option.entity';
 import { PlayerResult } from '../../modules/quests/player-result.entity';
 import { PartyInvitation } from '../../modules/parties/party-invitation.entity';
+import { Achievement } from '../../modules/achievements/achievement.entity';
 
 // ─── Conexión ──────────────────────────────────────────────────────────────────
 const AppDataSource = new DataSource({
@@ -46,7 +47,7 @@ const AppDataSource = new DataSource({
   database: process.env.POSTGRES_DB       ?? 'studyquest',
   entities: [
     User, FriendRequest, Subject, Party, PartyMember, ChatMessage, PartyActivity,
-    Quest, QuizQuestion, QuizOption, PlayerResult, PartyInvitation
+    Quest, QuizQuestion, QuizOption, PlayerResult, PartyInvitation, Achievement
   ],
   synchronize: false,
   logging: false,
@@ -65,6 +66,7 @@ const SUBJECTS_DATA = [
 ];
 
 const USERS_DATA = [
+  { email: 'admin@studyquest.dev', username: 'admin_sq',   displayName: 'Admin',           password: 'AdminPass123!', semester: 1, role: 'ADMIN' },
   { email: 'alice@studyquest.dev', username: 'alice_dev',  displayName: 'Alice García',   password: 'Password123!', semester: 4 },
   { email: 'bob@studyquest.dev',   username: 'bobby_b',    displayName: 'Bob Martínez',   password: 'Password123!', semester: 3 },
   { email: 'carol@studyquest.dev', username: 'carol_dev',  displayName: 'Carol López',    password: 'Password123!', semester: 5 },
@@ -72,6 +74,16 @@ const USERS_DATA = [
   { email: 'eve@studyquest.dev',   username: 'eve_hacker', displayName: 'Eve Fernández',  password: 'Password123!', semester: 2 },
   { email: 'frank@studyquest.dev', username: 'frank_tank', displayName: 'Frank Gómez',    password: 'Password123!', semester: 3 },
   { email: 'grace@studyquest.dev', username: 'grace_hopp', displayName: 'Grace Hopper',   password: 'Password123!', semester: 4 },
+];
+
+const ACHIEVEMENTS_DATA = [
+  { code: 'FIRST_QUEST',      name: 'Primera Quest',        icon: '🎯', category: 'academic',    description: 'Completaste tu primera quest.',          points: 50 },
+  { code: 'QUEST_STREAK_3',   name: 'En Racha',             icon: '🔥', category: 'academic',    description: 'Mantuviste una racha de 3 días.',         points: 100 },
+  { code: 'QUEST_STREAK_5',   name: 'Imparable',            icon: '⚡', category: 'academic',    description: 'Mantuviste una racha de 5 días.',         points: 200 },
+  { code: 'FIRST_PARTY',      name: 'Primera Party',        icon: '🎉', category: 'social',      description: 'Te uniste a tu primera party de estudio.', points: 50 },
+  { code: 'SOCIAL_BUTTERFLY', name: 'Alma de la Fiesta',    icon: '🦋', category: 'social',      description: 'Participaste en 5 parties diferentes.',    points: 150 },
+  { code: 'LEVEL_5',          name: 'Estudiante Aplicado',  icon: '📚', category: 'progression', description: 'Alcanzaste el nivel 5.',                    points: 100 },
+  { code: 'LEVEL_10',         name: 'Maestro del Estudio',  icon: '🏆', category: 'progression', description: 'Alcanzaste el nivel 10.',                   points: 250 },
 ];
 
 // ─── Main ──────────────────────────────────────────────────────────────────────
@@ -121,6 +133,7 @@ async function seed() {
       university:   UNIVERSITY,
       career:       CAREER,
       semester:     ud.semester,
+      role:         (ud as any).role ?? 'USER',
       passwordHash,
       stats: {
         xp: 0, level: 0, elo: 1200, quizzesPlayed: 0, quizzesWon: 0,
@@ -134,7 +147,7 @@ async function seed() {
 
   // ── 3. Inscribir usuarios en materias ────────────────────────────────────────
   console.log('\n📝  Inscribiendo usuarios en materias...');
-  const [alice, bob, carol, dave, eve, frank, grace] = savedUsers;
+  const [_admin, alice, bob, carol, dave, eve, frank, grace] = savedUsers;
   const [am2, aed, bd, so, rc] = savedSubjects;
 
   console.log('\n🤝  Creando amistades de prueba...');
@@ -151,6 +164,20 @@ async function seed() {
     }),
   ]);
   console.log('   ✔  Solicitudes de amistad seeded');
+
+  // ── 3b. Logros ──────────────────────────────────────────────────────────────────
+  console.log('\n🏆  Creando logros...');
+  const achievementRepo = AppDataSource.getRepository(Achievement);
+
+  for (const ad of ACHIEVEMENTS_DATA) {
+    const existing = await achievementRepo.findOneBy({ code: ad.code });
+    if (existing) {
+      console.log(`   ⚠️  Logro "${ad.code}" ya existe — omitido`);
+      continue;
+    }
+    await achievementRepo.save(achievementRepo.create(ad));
+    console.log(`   ✔  ${ad.icon} ${ad.name}`);
+  }
 
   // CORRECTO: AppDataSource.createQueryBuilder().relation(...)
   // INCORRECTO (bug original): subjectRepo.createQueryBuilder().relation(...)

--- a/backend/src/gateways/matchmaking/matchmaking.gateway.ts
+++ b/backend/src/gateways/matchmaking/matchmaking.gateway.ts
@@ -270,4 +270,13 @@ export class MatchmakingGateway
   handleChatMessageCreated(payload: { partyId: string; message: any }) {
     this.server.to(payload.partyId).emit('chat:message', payload.message);
   }
+
+  @OnEvent('achievement.unlocked')
+  handleAchievementUnlocked(payload: { userId: string; achievement: any }) {
+    for (const [socketId, conn] of this.connections) {
+      if (conn.userId === payload.userId) {
+        this.server.to(socketId).emit('achievement:unlocked', payload.achievement);
+      }
+    }
+  }
 }

--- a/backend/src/modules/achievements/achievement.entity.ts
+++ b/backend/src/modules/achievements/achievement.entity.ts
@@ -1,0 +1,39 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+@Entity('achievements')
+export class Achievement {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ unique: true, length: 50 })
+  @Index()
+  code: string;
+
+  @Column({ length: 100 })
+  name: string;
+
+  @Column({ type: 'text' })
+  description: string;
+
+  @Column({ length: 10 })
+  icon: string;
+
+  @Column({ length: 30 })
+  category: string;
+
+  @Column({ type: 'int', default: 0 })
+  points: number;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+}

--- a/backend/src/modules/achievements/achievements.controller.ts
+++ b/backend/src/modules/achievements/achievements.controller.ts
@@ -1,0 +1,52 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Body,
+  Param,
+  UseGuards,
+  Req,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard, Roles, Role } from '../../common/roles';
+import { AchievementsService } from './achievements.service';
+import { Achievement } from './achievement.entity';
+
+@Controller()
+@UseGuards(JwtAuthGuard)
+export class AchievementsController {
+  constructor(private readonly achievementsService: AchievementsService) {}
+
+  @Get('achievements')
+  findAll(): Promise<Achievement[]> {
+    return this.achievementsService.findAll();
+  }
+
+  @Get('users/me/achievements')
+  findMyAchievements(@Req() req: any) {
+    return this.achievementsService.findByUser(req.user.userId);
+  }
+
+  @Post('achievements')
+  @UseGuards(RolesGuard)
+  @Roles(Role.ADMIN)
+  create(@Body() body: Partial<Achievement>) {
+    return this.achievementsService.create(body);
+  }
+
+  @Put('achievements/:id')
+  @UseGuards(RolesGuard)
+  @Roles(Role.ADMIN)
+  update(@Param('id') id: string, @Body() body: Partial<Achievement>) {
+    return this.achievementsService.update(id, body);
+  }
+
+  @Delete('achievements/:id')
+  @UseGuards(RolesGuard)
+  @Roles(Role.ADMIN)
+  remove(@Param('id') id: string) {
+    return this.achievementsService.remove(id);
+  }
+}

--- a/backend/src/modules/achievements/achievements.module.ts
+++ b/backend/src/modules/achievements/achievements.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Achievement } from './achievement.entity';
+import { UserAchievement } from './user-achievement.entity';
+import { AchievementsService } from './achievements.service';
+import { AchievementsController } from './achievements.controller';
+import { UsersModule } from '../users/users.module';
+import { PartiesModule } from '../parties/parties.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Achievement, UserAchievement]),
+    UsersModule,
+    PartiesModule,
+  ],
+  controllers: [AchievementsController],
+  providers: [AchievementsService],
+  exports: [AchievementsService],
+})
+export class AchievementsModule {}

--- a/backend/src/modules/achievements/achievements.service.ts
+++ b/backend/src/modules/achievements/achievements.service.ts
@@ -1,0 +1,123 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { EventEmitter2, OnEvent } from '@nestjs/event-emitter';
+import { Achievement } from './achievement.entity';
+import { UserAchievement } from './user-achievement.entity';
+import { UsersService } from '../users/users.service';
+import { PartyMember } from '../parties/party-member.entity';
+
+@Injectable()
+export class AchievementsService {
+  private readonly logger = new Logger(AchievementsService.name);
+
+  constructor(
+    @InjectRepository(Achievement)
+    private readonly achievementRepo: Repository<Achievement>,
+    @InjectRepository(UserAchievement)
+    private readonly userAchievementRepo: Repository<UserAchievement>,
+    @InjectRepository(PartyMember)
+    private readonly partyMemberRepo: Repository<PartyMember>,
+    private readonly usersService: UsersService,
+    private readonly eventEmitter: EventEmitter2,
+  ) {}
+
+  // ─── CRUD ──────────────────────────────────────────────────────────────────────
+
+  async findAll(): Promise<Achievement[]> {
+    return this.achievementRepo.find({ order: { category: 'ASC', code: 'ASC' } });
+  }
+
+  async findByUser(userId: string): Promise<UserAchievement[]> {
+    return this.userAchievementRepo.find({
+      where: { userId },
+      relations: ['achievement'],
+      order: { unlockedAt: 'DESC' },
+    });
+  }
+
+  async create(data: Partial<Achievement>): Promise<Achievement> {
+    const achievement = this.achievementRepo.create(data);
+    return this.achievementRepo.save(achievement);
+  }
+
+  async update(id: string, data: Partial<Achievement>): Promise<Achievement> {
+    const achievement = await this.achievementRepo.findOneBy({ id });
+    if (!achievement) throw new NotFoundException('Logro no encontrado');
+    Object.assign(achievement, data);
+    return this.achievementRepo.save(achievement);
+  }
+
+  async remove(id: string): Promise<void> {
+    const result = await this.achievementRepo.delete(id);
+    if (result.affected === 0) throw new NotFoundException('Logro no encontrado');
+  }
+
+  // ─── Event Listeners ───────────────────────────────────────────────────────────
+
+  @OnEvent('quest.completed')
+  async onQuestCompleted({ userId }: { userId: string }) {
+    try {
+      const user = await this.usersService.findById(userId);
+      const stats = user.stats;
+
+      await this.tryUnlock(userId, 'FIRST_QUEST', stats.quizzesPlayed >= 1);
+      await this.tryUnlock(userId, 'QUEST_STREAK_3', stats.currentStreak >= 3);
+      await this.tryUnlock(userId, 'QUEST_STREAK_5', stats.currentStreak >= 5);
+
+      // Level-based achievements
+      await this.tryUnlock(userId, 'LEVEL_5', stats.level >= 5);
+      await this.tryUnlock(userId, 'LEVEL_10', stats.level >= 10);
+    } catch (err) {
+      this.logger.error(`Error evaluando logros para quest.completed (user=${userId}):`, err);
+    }
+  }
+
+  @OnEvent('party.member_joined')
+  async onPartyJoined({ userId }: { userId: string }) {
+    try {
+      const partyCount = await this.partyMemberRepo.count({ where: { userId } });
+      await this.tryUnlock(userId, 'FIRST_PARTY', partyCount >= 1);
+      await this.tryUnlock(userId, 'SOCIAL_BUTTERFLY', partyCount >= 5);
+    } catch (err) {
+      this.logger.error(`Error evaluando logros para party.member_joined (user=${userId}):`, err);
+    }
+  }
+
+  // ─── Unlock logic ──────────────────────────────────────────────────────────────
+
+  private async tryUnlock(userId: string, code: string, condition: boolean): Promise<void> {
+    if (!condition) return;
+
+    const achievement = await this.achievementRepo.findOneBy({ code });
+    if (!achievement) return;
+
+    // Check if already unlocked
+    const existing = await this.userAchievementRepo.findOneBy({
+      userId,
+      achievementId: achievement.id,
+    });
+    if (existing) return;
+
+    const userAchievement = this.userAchievementRepo.create({
+      userId,
+      achievementId: achievement.id,
+    });
+    await this.userAchievementRepo.save(userAchievement);
+
+    this.logger.log(`🏆 Logro desbloqueado: ${achievement.icon} ${achievement.name} para user=${userId}`);
+
+    this.eventEmitter.emit('achievement.unlocked', {
+      userId,
+      achievement: {
+        id: achievement.id,
+        code: achievement.code,
+        name: achievement.name,
+        description: achievement.description,
+        icon: achievement.icon,
+        category: achievement.category,
+        points: achievement.points,
+      },
+    });
+  }
+}

--- a/backend/src/modules/achievements/user-achievement.entity.ts
+++ b/backend/src/modules/achievements/user-achievement.entity.ts
@@ -1,0 +1,37 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Unique,
+  Index,
+} from 'typeorm';
+import { User } from '../users/user.entity';
+import { Achievement } from './achievement.entity';
+
+@Entity('user_achievements')
+@Unique(['userId', 'achievementId'])
+export class UserAchievement {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'user_id' })
+  @Index()
+  userId: string;
+
+  @Column({ name: 'achievement_id' })
+  achievementId: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'user_id' })
+  user: User;
+
+  @ManyToOne(() => Achievement, { eager: true, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'achievement_id' })
+  achievement: Achievement;
+
+  @CreateDateColumn({ name: 'unlocked_at' })
+  unlockedAt: Date;
+}

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -13,7 +13,7 @@ export class AuthService {
 
   async register(dto: RegisterDto) {
     const user = await this.usersService.create(dto);
-    return this.buildTokens(user.id, user.email, user.username);
+    return this.buildTokens(user.id, user.email, user.username, user.role);
   }
 
   async login(dto: LoginDto) {
@@ -21,7 +21,7 @@ export class AuthService {
     if (!user || !(await bcrypt.compare(dto.password, user.passwordHash))) {
       throw new UnauthorizedException('Credenciales incorrectas');
     }
-    return this.buildTokens(user.id, user.email, user.username);
+    return this.buildTokens(user.id, user.email, user.username, user.role);
   }
 
   async refresh(token: string) {
@@ -31,7 +31,7 @@ export class AuthService {
       const valid = await this.usersService.validateRefreshToken(userId, token);
       if (!valid) throw new UnauthorizedException('Refresh token inválido');
       const user = await this.usersService.findById(userId);
-      return this.buildTokens(user.id, user.email, user.username);
+      return this.buildTokens(user.id, user.email, user.username, user.role);
     } catch {
       throw new UnauthorizedException('Refresh token inválido');
     }
@@ -42,8 +42,8 @@ export class AuthService {
     await this.usersService.removeRefreshToken(userId, hashed);
   }
 
-  private async buildTokens(userId: string, email: string, username: string) {
-    const payload = { sub: userId, email, username };
+  private async buildTokens(userId: string, email: string, username: string, role = 'USER') {
+    const payload = { sub: userId, email, username, role };
     const [accessToken, refreshToken] = await Promise.all([
       this.jwtService.signAsync(payload, { expiresIn: '15m' }),
       this.jwtService.signAsync(payload, { expiresIn: '30d' }),

--- a/backend/src/modules/auth/jwt.strategy.ts
+++ b/backend/src/modules/auth/jwt.strategy.ts
@@ -16,11 +16,12 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     });
   }
 
-  validate(payload: { sub: string; email: string; username: string }) {
+  validate(payload: { sub: string; email: string; username: string; role?: string }) {
     return {
       userId: payload.sub,
       email: payload.email,
       username: payload.username,
+      role: payload.role ?? 'USER',
     };
   }
 }

--- a/backend/src/modules/parties/parties.service.ts
+++ b/backend/src/modules/parties/parties.service.ts
@@ -251,6 +251,8 @@ export class PartiesService {
         'Creó la party (como líder)',
       );
 
+      this.eventEmitter.emit('party.member_joined', { partyId: party.id, userId });
+
       return result;
     });
   }
@@ -660,6 +662,8 @@ export class PartiesService {
         userId,
         `Se unió a la party`,
       );
+
+      this.eventEmitter.emit('party.member_joined', { partyId, userId });
 
       if (statusChanged) {
         await this.logActivity(

--- a/backend/src/modules/users/user.entity.ts
+++ b/backend/src/modules/users/user.entity.ts
@@ -10,6 +10,7 @@ import {
   Index,
 } from 'typeorm';
 import { DEFAULT_ELO } from '../../common/leagues';
+import { Role } from '../../common/roles';
 import { Subject } from '../subjects/subject.entity';
 import { PartyMember } from '../parties/party-member.entity';
 
@@ -64,6 +65,9 @@ export class User {
 
   @Column({ type: 'smallint', default: 1 })
   semester: number;
+
+  @Column({ type: 'varchar', length: 10, default: Role.USER })
+  role: Role;
 
   @ManyToMany(() => Subject, (s) => s.enrolledUsers, { eager: false })
   @JoinTable({

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "framer-motion": "^12.38.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-hot-toast": "^2.6.0",
         "react-router-dom": "^7.13.2",
         "recharts": "^2.15.4",
         "socket.io-client": "^4.8.3",
@@ -3445,6 +3446,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/goober": {
+      "version": "2.1.19",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.19.tgz",
+      "integrity": "sha512-U7veizMqxyKlM58+Z5j2ngJBH/r9siDmxpvNxSw0PylF6WQvrASJEZrxh1hidRBJc2jqoBVSyOban5u8m+6Rxg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "license": "MIT",
@@ -4384,6 +4394,23 @@
       },
       "peerDependencies": {
         "react": "^19.2.4"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.6.0.tgz",
+      "integrity": "sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-is": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "framer-motion": "^12.38.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-hot-toast": "^2.6.0",
     "react-router-dom": "^7.13.2",
     "recharts": "^2.15.4",
     "socket.io-client": "^4.8.3",

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,5 +1,6 @@
 import { Navigate } from 'react-router-dom'
 import { useAuthStore } from '../store/authStore'
+import { useAchievementNotifier } from '../hooks/useAchievementNotifier'
 import type { ReactNode } from 'react'
 
 interface Props {
@@ -8,6 +9,7 @@ interface Props {
 
 export function ProtectedRoute({ children }: Props) {
   const { isAuthenticated } = useAuthStore()
+  useAchievementNotifier()
   if (!isAuthenticated) return <Navigate to="/auth" replace />
   return <>{children}</>
 }

--- a/frontend/src/hooks/useAchievementNotifier.ts
+++ b/frontend/src/hooks/useAchievementNotifier.ts
@@ -1,0 +1,38 @@
+import { useEffect } from 'react'
+import toast from 'react-hot-toast'
+import { useSocket } from './useSocket'
+
+interface AchievementPayload {
+  id: string
+  code: string
+  name: string
+  description: string
+  icon: string
+  category: string
+  points: number
+}
+
+export function useAchievementNotifier() {
+  const { socket } = useSocket()
+
+  useEffect(() => {
+    const handler = (achievement: AchievementPayload) => {
+      toast(`${achievement.icon} ¡Logro desbloqueado: ${achievement.name}!`, {
+        duration: 4000,
+        style: {
+          background: '#1a1a2e',
+          color: '#e2e8f0',
+          border: '1px solid #7c3aed',
+          borderRadius: '12px',
+          fontWeight: 600,
+          fontSize: '14px',
+        },
+      })
+    }
+
+    socket.on('achievement:unlocked', handler)
+    return () => {
+      socket.off('achievement:unlocked', handler)
+    }
+  }, [socket])
+}

--- a/frontend/src/hooks/useAchievements.ts
+++ b/frontend/src/hooks/useAchievements.ts
@@ -1,0 +1,54 @@
+import { useState, useEffect } from 'react'
+import { achievementService } from '../services/achievementService'
+import type { Achievement, UserAchievement } from '../services/achievementService'
+
+export interface EnrichedAchievement extends Achievement {
+  unlocked: boolean
+  unlockedAt: string | null
+}
+
+export function useAchievements() {
+  const [achievements, setAchievements] = useState<EnrichedAchievement[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function load() {
+      try {
+        const [all, mine] = await Promise.all([
+          achievementService.getAll(),
+          achievementService.getMyAchievements(),
+        ])
+
+        if (cancelled) return
+
+        const unlockedMap = new Map<string, UserAchievement>()
+        for (const ua of mine) {
+          unlockedMap.set(ua.achievementId, ua)
+        }
+
+        const enriched: EnrichedAchievement[] = all.map((a) => {
+          const ua = unlockedMap.get(a.id)
+          return {
+            ...a,
+            unlocked: !!ua,
+            unlockedAt: ua?.unlockedAt ?? null,
+          }
+        })
+
+        setAchievements(enriched)
+      } catch {
+        if (!cancelled) setError('No se pudieron cargar los logros')
+      } finally {
+        if (!cancelled) setIsLoading(false)
+      }
+    }
+
+    load()
+    return () => { cancelled = true }
+  }, [])
+
+  return { achievements, isLoading, error }
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1442,6 +1442,66 @@ input, textarea, select { font-family: inherit; }
   color: var(--text-secondary);
 }
 
+/* ─── Achievements Grid ─────────────────────────────────────────────────────── */
+
+.achievements-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(90px, 1fr));
+  gap: 10px;
+  padding: 0 16px;
+}
+
+.achievement-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 14px 8px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  background: var(--bg-surface);
+  text-align: center;
+  transition: all 0.25s ease;
+  cursor: default;
+}
+
+.achievement-item--unlocked {
+  border-color: rgba(124, 58, 237, 0.4);
+  background: rgba(124, 58, 237, 0.06);
+  box-shadow: 0 0 12px rgba(124, 58, 237, 0.15);
+}
+
+.achievement-item--unlocked:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 20px rgba(124, 58, 237, 0.25);
+}
+
+.achievement-item--locked {
+  opacity: 0.35;
+  filter: grayscale(0.8);
+}
+
+.achievement-icon {
+  font-size: 28px;
+  line-height: 1;
+}
+
+.achievement-name {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  line-height: 1.3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.achievement-item--unlocked .achievement-name {
+  color: var(--text-primary);
+}
+
 /* ─── League System ──────────────────────────────────────────────────────────── */
 
 .league-banner {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
+import { Toaster } from 'react-hot-toast'
 import './index.css'
 import App from './App.tsx'
 
@@ -9,5 +10,6 @@ createRoot(document.getElementById('root')!).render(
     <BrowserRouter>
       <App />
     </BrowserRouter>
+    <Toaster position="top-center" />
   </StrictMode>,
 )

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -5,11 +5,13 @@ import { useAuthStore } from '../store/authStore'
 import { useAuth } from '../hooks/useAuth'
 import { userService } from '../services/userService'
 import { getLeague, getEloProgress, DEFAULT_ELO, LEAGUES } from '../utils/leagues'
+import { useAchievements } from '../hooks/useAchievements'
 
 export default function ProfilePage() {
   const { user, setUser } = useAuthStore()
   const { logout } = useAuth()
   const [isEditing, setIsEditing] = useState(false)
+  const { achievements, isLoading: achievementsLoading } = useAchievements()
 
   useEffect(() => {
     userService.getMe().then(setUser).catch(console.error)
@@ -103,6 +105,29 @@ export default function ProfilePage() {
           <span className="stat-label">Racha</span>
         </div>
       </div>
+
+      {/* ─── Medals / Achievements ──────────────────────────────────── */}
+      <h3 className="section-title" style={{ marginTop: '16px' }}>Medallas</h3>
+      {achievementsLoading ? (
+        <div className="center-spinner" style={{ padding: '20px' }}><Spinner size="sm" /></div>
+      ) : achievements.length === 0 ? (
+        <div className="empty-state" style={{ padding: '20px' }}>
+          <p className="empty-text" style={{ fontSize: '14px' }}>No hay logros disponibles aún</p>
+        </div>
+      ) : (
+        <div className="achievements-grid">
+          {achievements.map((a) => (
+            <div
+              key={a.id}
+              className={`achievement-item ${a.unlocked ? 'achievement-item--unlocked' : 'achievement-item--locked'}`}
+              title={a.unlocked ? `${a.name} — ${a.description}` : `🔒 ${a.name} — ${a.description}`}
+            >
+              <span className="achievement-icon">{a.icon}</span>
+              <span className="achievement-name">{a.name}</span>
+            </div>
+          ))}
+        </div>
+      )}
 
       {/* ─── League Ladder ─────────────────────────────────────────── */}
       <h3 className="section-title" style={{ marginTop: '16px' }}>Ligas</h3>

--- a/frontend/src/services/achievementService.ts
+++ b/frontend/src/services/achievementService.ts
@@ -1,0 +1,31 @@
+import { api } from './api'
+
+export interface Achievement {
+  id: string
+  code: string
+  name: string
+  description: string
+  icon: string
+  category: string
+  points: number
+}
+
+export interface UserAchievement {
+  id: string
+  userId: string
+  achievementId: string
+  unlockedAt: string
+  achievement: Achievement
+}
+
+export const achievementService = {
+  async getAll(): Promise<Achievement[]> {
+    const { data } = await api.get<Achievement[]>('/achievements')
+    return data
+  },
+
+  async getMyAchievements(): Promise<UserAchievement[]> {
+    const { data } = await api.get<UserAchievement[]>('/users/me/achievements')
+    return data
+  },
+}


### PR DESCRIPTION
## Resolves

Closes #59, Closes #84, Closes #85, Closes #86, Closes #87, Closes #99, Closes #100,, Closes #101

## What changed

- **Sistema de Roles:** Se agregó el rol `ADMIN` al `User` y JWT para proteger rutas sensibles.
- **Logros (Backend):** Entidades `Achievement` y `UserAchievement`, endpoints CRUD y lógica de evaluación mediante interceptores de eventos (`quest.completed` y `party.member_joined`).
- **Seed Actualizado:** El comando de seed ahora crea un usuario administrador y 7 logros base listos para usar.
- **Notificaciones (WebSockets):** Se envían eventos `achievement:unlocked` de forma individualizada a través de Socket.io y se muestran como notificaciones Toast globales en React (`react-hot-toast`).
- **Perfil de Usuario:** Nueva sección en la UI para visualizar la colección de medallas (bloqueadas/desbloqueadas).

## How to test

1. Actualizar dependencias y base de datos: Ejecutar `npm run seed` en el backend para generar el catálogo de logros.
2. Loguearse en el frontend e ir a la vista de "Perfil" para ver el tablero de medallas bloqueadas.
3. Completar una acción que otorgue un logro (ej. jugar una Quest para obtener "Primera Quest").
4. Verificar que aparezca la notificación flotante (Toast) en tiempo real confirmando el desbloqueo.
5. Volver al perfil y corroborar que la medalla correspondiente ahora está resaltada a color.

## Checklist

- [x] Linked issue is included
- [x] Changes were tested
- [x] Relevant docs were updated if needed
