### PR TITLE
Feat/party chat rich messages plan

### DIFF
--- a/backend/src/modules/parties/parties.service.ts
+++ b/backend/src/modules/parties/parties.service.ts
@@ -220,7 +220,7 @@ export class PartiesService {
       resolvedSubjectId = user.enrolledSubjects[0].id;
     }
 
-    return this.dataSource.transaction(async (em) => {
+    const result = await this.dataSource.transaction(async (em) => {
       const party = em.create(Party, {
         subjectId: resolvedSubjectId,
         maxMembers,
@@ -243,18 +243,18 @@ export class PartiesService {
       });
       if (!result) throw new NotFoundException('Error al crear la party');
 
-      // Log que se creó la party después de la transacción
-      await this.logActivity(
-        party.id,
-        'member_joined',
-        userId,
-        'Creó la party (como líder)',
-      );
-
-      this.eventEmitter.emit('party.member_joined', { partyId: party.id, userId });
-
       return result;
     });
+
+    await this.logActivity(
+      result.id,
+      'member_joined',
+      userId,
+      'Creó la party (como líder)',
+    );
+    this.eventEmitter.emit('party.member_joined', { partyId: result.id, userId });
+
+    return result;
   }
 
   async findById(id: string): Promise<Party> {
@@ -371,7 +371,14 @@ export class PartiesService {
    *  - Si es leader y está solo → cierra la party.
    */
   async leaveParty(partyId: string, userId: string): Promise<void> {
-    return this.dataSource.transaction(async (em) => {
+    const deferredActivities: Array<{
+      type: ActivityType;
+      userId?: string;
+      description?: string;
+      metadata?: any;
+    }> = [];
+
+    await this.dataSource.transaction(async (em) => {
       const memberRecord = await em.findOne(PartyMember, {
         where: { partyId, userId },
       });
@@ -379,12 +386,11 @@ export class PartiesService {
 
       if (memberRecord.role !== 'leader') {
         await em.remove(memberRecord);
-        await this.logActivity(
-          partyId,
-          'member_left',
+        deferredActivities.push({
+          type: 'member_left',
           userId,
-          'Salió de la party',
-        );
+          description: 'Salió de la party',
+        });
         return;
       }
 
@@ -399,13 +405,12 @@ export class PartiesService {
         // Estaba solo → cerrar party
         await em.remove(memberRecord);
         await em.update(Party, partyId, { status: 'closed', closedAt: new Date() });
-        await this.logActivity(
-          partyId,
-          'party_status_changed',
+        deferredActivities.push({
+          type: 'party_status_changed',
           userId,
-          'Party cerrada (líder se fue y no había otros miembros)',
-          { oldStatus: 'active', newStatus: 'closed' },
-        );
+          description: 'Party cerrada (líder se fue y no había otros miembros)',
+          metadata: { oldStatus: 'active', newStatus: 'closed' },
+        });
         return;
       }
 
@@ -414,19 +419,27 @@ export class PartiesService {
       await em.update(PartyMember, { id: newLeader.id }, { role: 'leader' });
       await em.remove(memberRecord);
 
-      await this.logActivity(
-        partyId,
-        'member_left',
+      deferredActivities.push({
+        type: 'member_left',
         userId,
-        'Salió de la party (era líder)',
-      );
+        description: 'Salió de la party (era líder)',
+      });
+      deferredActivities.push({
+        type: 'member_promoted',
+        userId: newLeader.userId,
+        description: 'Fue promovido a líder',
+      });
+    });
+
+    for (const activity of deferredActivities) {
       await this.logActivity(
         partyId,
-        'member_promoted',
-        newLeader.userId,
-        `Fue promovido a líder`,
+        activity.type,
+        activity.userId,
+        activity.description,
+        activity.metadata,
       );
-    });
+    }
   }
 
   async updateVisibility(partyId: string, userId: string, isPrivate: boolean): Promise<void> {
@@ -611,7 +624,9 @@ export class PartiesService {
    * Une al usuario autenticado a una party existente si hay slots disponibles.
    */
   async joinParty(partyId: string, userId: string): Promise<Party> {
-    return this.dataSource.transaction(async (em) => {
+    let statusChanged = false;
+
+    const updated = await this.dataSource.transaction(async (em) => {
       // Obtenemos la party con exclusividad (lock) pero SIN JOINs para no romper FOR UPDATE
       const party = await em.findOne(Party, {
         where: { id: partyId },
@@ -642,7 +657,6 @@ export class PartiesService {
       });
       await em.save(member);
 
-      let statusChanged = false;
       // Si la party se llenó, pasarla a active
       if (party.members.length + 1 >= party.maxMembers) {
         await em.update(Party, partyId, { status: 'active' });
@@ -655,27 +669,27 @@ export class PartiesService {
       });
       if (!updated) throw new NotFoundException('Party no encontrada tras unirse');
 
-      // Log activity después de la transacción
-      await this.logActivity(
-        partyId,
-        'member_joined',
-        userId,
-        `Se unió a la party`,
-      );
-
-      this.eventEmitter.emit('party.member_joined', { partyId, userId });
-
-      if (statusChanged) {
-        await this.logActivity(
-          partyId,
-          'party_status_changed',
-          undefined,
-          'Party se llenó y pasó a activa',
-          { oldStatus: 'forming', newStatus: 'active' },
-        );
-      }
-
       return updated;
     });
+
+    await this.logActivity(
+      partyId,
+      'member_joined',
+      userId,
+      'Se unió a la party',
+    );
+    this.eventEmitter.emit('party.member_joined', { partyId, userId });
+
+    if (statusChanged) {
+      await this.logActivity(
+        partyId,
+        'party_status_changed',
+        undefined,
+        'Party se llenó y pasó a activa',
+        { oldStatus: 'forming', newStatus: 'active' },
+      );
+    }
+
+    return updated;
   }
 }

--- a/frontend/src/hooks/useMatch.test.ts
+++ b/frontend/src/hooks/useMatch.test.ts
@@ -1,0 +1,118 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { useMatch } from './useMatch'
+import { partyService } from '../services/partyService'
+
+vi.mock('../services/partyService', () => ({
+  partyService: {
+    discover: vi.fn(),
+    join: vi.fn(),
+  },
+}))
+
+const partyA = {
+  id: 'party-a',
+  subjectId: 'subject-a',
+  subject: { id: 'subject-a', name: 'Bases de Datos', code: 'BD' },
+  members: [],
+  maxMembers: 4,
+  status: 'forming',
+  quests: [],
+  isPrivate: false,
+  createdAt: '',
+  updatedAt: '',
+} as any
+
+const partyB = {
+  ...partyA,
+  id: 'party-b',
+  subject: { id: 'subject-b', name: 'Algoritmos y Estructuras de Datos', code: 'AED' },
+} as any
+
+describe('useMatch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('loads discoverable parties over REST and exposes the top card', async () => {
+    vi.mocked(partyService.discover).mockResolvedValue([partyA, partyB])
+
+    const { result } = renderHook(() => useMatch())
+
+    await act(async () => {
+      await result.current.load()
+    })
+
+    expect(partyService.discover).toHaveBeenCalledTimes(1)
+    expect(result.current.status).toBe('ready')
+    expect(result.current.parties).toHaveLength(2)
+    expect(result.current.top).toEqual(partyB)
+  })
+
+  it('discards only the local top card without calling the backend', async () => {
+    vi.mocked(partyService.discover).mockResolvedValue([partyA, partyB])
+
+    const { result } = renderHook(() => useMatch())
+
+    await act(async () => {
+      await result.current.load()
+    })
+
+    act(() => {
+      result.current.discard('party-b')
+    })
+
+    expect(partyService.join).not.toHaveBeenCalled()
+    expect(result.current.top).toEqual(partyA)
+    expect(result.current.status).toBe('ready')
+  })
+
+  it('joins a party over REST and removes it from the deck', async () => {
+    vi.mocked(partyService.discover).mockResolvedValue([partyA, partyB])
+    vi.mocked(partyService.join).mockResolvedValue({ ...partyB, status: 'active' })
+
+    const { result } = renderHook(() => useMatch())
+
+    await act(async () => {
+      await result.current.load()
+    })
+
+    let joined: any
+    await act(async () => {
+      joined = await result.current.join('party-b')
+    })
+
+    await waitFor(() => {
+      expect(partyService.join).toHaveBeenCalledWith('party-b')
+      expect(joined.id).toBe('party-b')
+      expect(result.current.top).toEqual(partyA)
+    })
+  })
+
+  it('moves to empty when there are no discoverable parties', async () => {
+    vi.mocked(partyService.discover).mockResolvedValue([])
+
+    const { result } = renderHook(() => useMatch())
+
+    await act(async () => {
+      await result.current.load()
+    })
+
+    expect(result.current.status).toBe('empty')
+    expect(result.current.top).toBeNull()
+  })
+
+  it('exposes an error state when discovery fails', async () => {
+    vi.mocked(partyService.discover).mockRejectedValue({
+      response: { data: { message: 'No se pudieron cargar las parties' } },
+    })
+
+    const { result } = renderHook(() => useMatch())
+
+    await act(async () => {
+      await result.current.load()
+    })
+
+    expect(result.current.status).toBe('error')
+    expect(result.current.error).toBe('No se pudieron cargar las parties')
+  })
+})

--- a/frontend/src/hooks/useMatch.ts
+++ b/frontend/src/hooks/useMatch.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react'
+import { useCallback, useState } from 'react'
 import { partyService, type Party } from '../services/partyService'
 
 export type MatchStatus = 'idle' | 'loading' | 'ready' | 'empty' | 'error'
@@ -11,6 +11,7 @@ export function useMatch() {
   const load = useCallback(async () => {
     setStatus('loading')
     setError(null)
+
     try {
       const data = await partyService.discover()
       setParties(data)
@@ -21,30 +22,26 @@ export function useMatch() {
     }
   }, [])
 
-  /** Eliminar del stack local sin llamar al backend (swipe left / descarte) */
   const discard = useCallback((partyId: string) => {
     setParties((prev) => {
-      const next = prev.filter((p) => p.id !== partyId)
+      const next = prev.filter((party) => party.id !== partyId)
       if (next.length === 0) setStatus('empty')
       return next
     })
   }, [])
 
-  /** Unirse y eliminar del stack (swipe right / aprobar) */
-  const join = useCallback(
-    async (partyId: string): Promise<Party> => {
-      const party = await partyService.join(partyId)
-      setParties((prev) => {
-        const next = prev.filter((p) => p.id !== partyId)
-        if (next.length === 0) setStatus('empty')
-        return next
-      })
-      return party
-    },
-    [],
-  )
+  const join = useCallback(async (partyId: string): Promise<Party> => {
+    const party = await partyService.join(partyId)
 
-  /** Top de la pila (la tarjeta que se muestra arriba) */
+    setParties((prev) => {
+      const next = prev.filter((candidate) => candidate.id !== partyId)
+      if (next.length === 0) setStatus('empty')
+      return next
+    })
+
+    return party
+  }, [])
+
   const top = parties[parties.length - 1] ?? null
 
   return { parties, top, status, error, load, discard, join }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -82,13 +82,20 @@ input, textarea, select { font-family: inherit; }
   height: 100%;
   display: flex;
   flex-direction: column;
-  padding: 0 0 80px; /* Padding for bottom nav */
   background: var(--bg-base);
   overflow-y: auto;
   overflow-x: hidden;
+  scroll-behavior: smooth;
 }
 
-.mobile-main { flex: 1; display: flex; flex-direction: column; gap: 12px; padding: 0 16px; min-height: 0; }
+.mobile-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 0;
+  padding: 0 16px calc(132px + env(safe-area-inset-bottom, 0px));
+}
 
 /* â”€â”€â”€ Bottom Navigation â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 .bottom-nav {
@@ -247,6 +254,7 @@ input, textarea, select { font-family: inherit; }
 .btn-ghost:hover:not(:disabled) { color: var(--text-primary); }
 
 .btn-danger { background: var(--red-bg); color: var(--red); border: 1px solid rgba(239,68,68,0.3); }
+.btn-danger:hover:not(:disabled) { background: rgba(127, 29, 29, 0.7); border-color: rgba(248, 113, 113, 0.45); color: #fca5a5; }
 
 .btn-sm { padding: 7px 14px; font-size: 13px; }
 .btn-md { padding: 11px 20px; font-size: 15px; }
@@ -319,7 +327,8 @@ input, textarea, select { font-family: inherit; }
 .party-banner {
   display: flex;
   align-items: center;
-  justify-content: flex-start;
+  justify-content: space-between;
+  gap: 14px;
   background: linear-gradient(135deg, rgba(124,58,237,0.15), rgba(16,185,129,0.1));
   border: 1px solid rgba(16,185,129,0.3);
   border-radius: var(--radius-lg);
@@ -328,11 +337,12 @@ input, textarea, select { font-family: inherit; }
   transition: transform 0.2s, box-shadow 0.2s;
 }
 .party-banner:hover { transform: translateY(-2px); box-shadow: var(--shadow-md); }
-.party-banner-info { display: flex; align-items: center; gap: 12px; }
+.party-banner .btn { flex-shrink: 0; margin-left: auto; }
+.party-banner-info { display: flex; align-items: center; gap: 12px; min-width: 0; flex: 1; }
 .party-banner-dot { width: 10px; height: 10px; background: var(--green); border-radius: var(--radius-full); box-shadow: 0 0 8px var(--green); animation: pulse 1.5s ease-in-out infinite; }
 @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.5; } }
 .party-banner-label { font-size: 11px; color: var(--green); font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; }
-.party-banner-name { font-size: 15px; font-weight: 700; }
+.party-banner-name { font-size: 15px; font-weight: 700; overflow: hidden; text-overflow: ellipsis; }
 
 .party-list { display: flex; flex-direction: column; gap: 12px; }
 .party-list-item { 
@@ -723,6 +733,14 @@ input, textarea, select { font-family: inherit; }
 .matchmaking-subject-chip { background: var(--accent-bg); border: 1px solid var(--accent-glow); border-radius: var(--radius-full); padding: 6px 14px; font-size: 13px; font-weight: 500; }
 .matchmaking-no-subjects { color: var(--text-muted); font-size: 14px; }
 .matchmaking-btn { min-width: 200px; }
+.matchmaking-screen {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px 0;
+}
 
 /* Radar animation */
 .search-animation { display: flex; flex-direction: column; align-items: center; gap: 32px; }
@@ -746,6 +764,7 @@ input, textarea, select { font-family: inherit; }
 .party-preview-title { font-size: 24px; font-weight: 800; }
 .party-preview-members { display: flex; gap: 16px; justify-content: center; flex-wrap: wrap; }
 .party-preview-member { display: flex; flex-direction: column; align-items: center; gap: 6px; font-size: 13px; }
+.party-preview-actions { display: flex; gap: 12px; flex-wrap: wrap; justify-content: center; }
 
 .waiting-screen { display: flex; flex-direction: column; align-items: center; gap: 20px; text-align: center; }
 .waiting-icon { font-size: 48px; }
@@ -1127,14 +1146,15 @@ input, textarea, select { font-family: inherit; }
   margin: 0 auto;
   width: 100%;
   background: var(--bg-base);
-  padding-bottom: 70px;
+  padding-bottom: calc(92px + env(safe-area-inset-bottom, 0px));
   overflow: hidden;
 }
 
 .mc-header {
   display: flex; align-items: center; justify-content: space-between; padding: 22px 20px 10px; flex-shrink: 0;
 }
-.mc-header-title { font-size: 22px; font-weight: 800; letter-spacing: -0.3px; }
+.mc-header-title { font-size: 22px; font-weight: 800; }
+.mc-header-subtitle { margin-top: 4px; font-size: 13px; color: var(--text-secondary); }
 .mc-filter-btn {
   width: 38px; height: 38px;
   border-radius: var(--radius-md);
@@ -1153,7 +1173,7 @@ input, textarea, select { font-family: inherit; }
   display: flex;
   align-items: stretch;
   justify-content: center;
-  padding: 30px 56px 20px; overflow: hidden;
+  padding: 24px 42px 18px; overflow: hidden;
 }
 
 .mc-state-screen { display: flex; flex-direction: column; align-items: center; gap: 14px; text-align: center; padding: 24px 16px; }
@@ -1249,7 +1269,7 @@ input, textarea, select { font-family: inherit; }
 .mc-btn-join { width: 68px; height: 68px; border-color: rgba(16,185,129,0.55); background: rgba(16,185,129,0.08); color: var(--green); }
 .mc-btn-join:not(:disabled):hover { background: rgba(16,185,129,0.18); box-shadow: 0 0 26px rgba(16,185,129,0.35); transform: scale(1.1); }
 
-.mc-footer-bar { padding: 0 16px 16px; flex-shrink: 0; }
+.mc-footer-bar { padding: 0 16px 22px; flex-shrink: 0; }
 .mc-footer-inner { display: flex; align-items: center; gap: 10px; background: var(--bg-elevated); border: 1px solid var(--border); border-radius: var(--radius-lg); padding: 13px 16px; }
 .mc-footer-plus { width: 26px; height: 26px; border-radius: var(--radius-full); background: var(--bg-surface); border: 1px solid var(--border); display: flex; align-items: center; justify-content: center; color: var(--text-muted); flex-shrink: 0; }
 .mc-footer-text { flex: 1; font-size: 13px; color: var(--text-secondary); }
@@ -1500,6 +1520,63 @@ input, textarea, select { font-family: inherit; }
 
 .achievement-item--unlocked .achievement-name {
   color: var(--text-primary);
+}
+
+.profile-actions-card {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  margin: 0 16px 72px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.profile-logout-panel {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 16px;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(239, 68, 68, 0.18);
+  background: linear-gradient(180deg, rgba(127, 29, 29, 0.18), rgba(12, 12, 22, 0.35));
+}
+
+.profile-logout-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.profile-logout-title {
+  font-size: 14px;
+  font-weight: 700;
+  color: #f5c2c7;
+}
+
+.profile-logout-text {
+  font-size: 13px;
+  line-height: 1.4;
+  color: var(--text-secondary);
+}
+
+.profile-logout-button {
+  flex-shrink: 0;
+  min-width: 96px;
+}
+
+@media (max-width: 480px) {
+  .profile-logout-panel {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .profile-logout-button {
+    width: 100%;
+  }
 }
 
 /* ─── League System ──────────────────────────────────────────────────────────── */
@@ -1915,11 +1992,3 @@ input, textarea, select { font-family: inherit; }
     height: 22px;
   }
 }
-
-
-
-
-
-
-
-

--- a/frontend/src/pages/MatchPage.test.tsx
+++ b/frontend/src/pages/MatchPage.test.tsx
@@ -1,0 +1,130 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import MatchPage from './MatchPage'
+import { useAuthStore } from '../store/authStore'
+import { useMatch } from '../hooks/useMatch'
+
+const navigate = vi.fn()
+const joinSpy = vi.fn()
+const loadSpy = vi.fn()
+const discardSpy = vi.fn()
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => navigate,
+  }
+})
+
+vi.mock('../hooks/useMatch', () => ({
+  useMatch: vi.fn(),
+}))
+
+const user = {
+  id: 'user-1',
+  username: 'alice_dev',
+  displayName: 'Alice Garcia',
+  avatarUrl: null,
+  university: 'UNC',
+  career: 'ISI',
+  semester: 4,
+  email: 'alice@studyquest.dev',
+  availability: [],
+  enrolledSubjects: [
+    { id: 'subject-1', name: 'Algoritmos y Estructuras de Datos', code: 'AED', career: 'ISI', university: 'UNC', semester: 3 },
+  ],
+  stats: {
+    xp: 0,
+    level: 1,
+    elo: 1000,
+    quizzesPlayed: 0,
+    quizzesWon: 0,
+    currentStreak: 0,
+    longestStreak: 0,
+    lastPlayedAt: null,
+  },
+  isActive: true,
+  createdAt: '',
+  updatedAt: '',
+} as any
+
+const party = {
+  id: 'party-1',
+  subjectId: 'subject-1',
+  subject: { id: 'subject-1', name: 'Algoritmos y Estructuras de Datos', code: 'AED' },
+  members: [{
+    id: 'member-1',
+    userId: 'user-2',
+    partyXp: 0,
+    isOnline: true,
+    joinedAt: '',
+    role: 'leader',
+    user: {
+      id: 'user-2',
+      username: 'bob_dev',
+      displayName: 'Bob Martinez',
+      avatarUrl: null,
+      stats: user.stats,
+    },
+  }],
+  maxMembers: 4,
+  status: 'forming',
+  quests: [{ id: 'quest-1', title: 'Repaso AED', status: 'active' }],
+  isPrivate: false,
+  createdAt: '',
+  updatedAt: '',
+} as any
+
+describe('MatchPage', () => {
+  beforeEach(() => {
+    navigate.mockReset()
+    joinSpy.mockReset()
+    loadSpy.mockReset()
+    discardSpy.mockReset()
+    useAuthStore.setState({
+      user,
+      accessToken: 'token',
+      refreshToken: 'refresh',
+      isAuthenticated: true,
+    })
+
+    vi.mocked(useMatch).mockReturnValue({
+      parties: [party],
+      top: party,
+      status: 'ready',
+      error: null,
+      load: loadSpy,
+      discard: discardSpy,
+      join: joinSpy.mockResolvedValue(party),
+    } as any)
+  })
+
+  it('shows the REST discovery card without queue confirmation copy', () => {
+    render(
+      <MemoryRouter initialEntries={['/match']}>
+        <MatchPage />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByText(/party discovery/i)).toBeInTheDocument()
+    expect(screen.getAllByText(/algoritmos y estructuras de datos/i).length).toBeGreaterThan(0)
+    expect(screen.queryByText(/esperando confirmaciones/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/persona en cola/i)).not.toBeInTheDocument()
+  })
+
+  it('joins the visible party and navigates to the party room', async () => {
+    render(
+      <MemoryRouter initialEntries={['/match']}>
+        <MatchPage />
+      </MemoryRouter>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /unirse/i }))
+
+    await waitFor(() => {
+      expect(joinSpy).toHaveBeenCalledWith('party-1')
+      expect(navigate).toHaveBeenCalledWith('/party/party-1')
+    })
+  })
+})

--- a/frontend/src/pages/MatchPage.tsx
+++ b/frontend/src/pages/MatchPage.tsx
@@ -1,69 +1,72 @@
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { motion, AnimatePresence, useMotionValue, useTransform } from 'framer-motion'
-import { useMatch } from '../hooks/useMatch'
-import { usePartyStore } from '../store/partyStore'
+import { AnimatePresence, motion, useMotionValue, useTransform } from 'framer-motion'
 import { BottomNav } from '../components/Layouts'
 import {
-  PartyCard,
   ActionButtons,
-  LoadingState,
-  ErrorState,
-  EmptyState,
   CreatePartyBar,
+  EmptyState,
+  ErrorState,
+  LoadingState,
+  PartyCard,
 } from '../components/MatchComponents'
+import { useMatch } from '../hooks/useMatch'
+import { usePartyStore } from '../store/partyStore'
 
 export default function MatchPage() {
   const navigate = useNavigate()
   const { setActiveParty } = usePartyStore()
-  const { top, status, error, load, discard, join } = useMatch()
+  const { parties, top, status, error, load, discard, join } = useMatch()
+  const [exitDir, setExitDir] = useState(0)
 
-  const [exitDir, setExitDir] = useState<number>(0)
-
-  useEffect(() => { load() }, [load])
-
-  // Motion setup
   const x = useMotionValue(0)
   const rotate = useTransform(x, [-250, 250], [-20, 20])
   const opacity = useTransform(x, [-250, 0, 250], [0.5, 1, 0.5])
 
+  useEffect(() => {
+    load()
+  }, [load])
+
   const handleJoin = async (partyId: string, programmatic = false) => {
     if (programmatic) setExitDir(1)
-    setTimeout(async () => {
-      try {
-        const party = await join(partyId)
-        setActiveParty(party)
-        navigate(`/party/${party.id}`)
-      } catch (err: any) {
-        alert(err?.response?.data?.message ?? 'No se pudo unir a la party')
-        load() // Recargar si falló
-      }
-    }, programmatic ? 200 : 0)
+    try {
+      const party = await join(partyId)
+      setActiveParty(party)
+      navigate(`/party/${party.id}`)
+    } catch (err: any) {
+      alert(err?.response?.data?.message ?? 'No se pudo unir a la party')
+      load()
+    }
   }
 
   const handleDiscard = (partyId: string, programmatic = false) => {
     if (programmatic) setExitDir(-1)
-    setTimeout(() => {
-      discard(partyId)
-      setExitDir(0)
-      x.set(0)
-    }, programmatic ? 200 : 0)
+    discard(partyId)
+    setExitDir(0)
+    x.set(0)
   }
 
   const handleDragEnd = (_e: any, info: { offset: { x: number } }) => {
+    if (!top) return
+
     const threshold = 120
     if (info.offset.x > threshold) {
-      setExitDir(1)
-      handleJoin(top!.id)
+      handleJoin(top.id)
     } else if (info.offset.x < -threshold) {
-      setExitDir(-1)
-      handleDiscard(top!.id)
+      handleDiscard(top.id)
     }
   }
 
   const showCard = status === 'ready' && !!top
 
-  // Variants para exit animation
+  const subtitleByStatus = {
+    idle: 'Cargando parties compatibles',
+    loading: 'Buscando parties compatibles',
+    ready: `${parties.length} party${parties.length === 1 ? '' : 's'} disponible${parties.length === 1 ? '' : 's'}`,
+    empty: 'No hay parties disponibles por ahora',
+    error: error ?? 'No pudimos cargar las parties',
+  }[status]
+
   const cardVariants = {
     enter: { scale: 0.95, opacity: 0, y: 20 },
     center: { scale: 1, opacity: 1, y: 0, x: 0, rotate: 0 },
@@ -73,15 +76,18 @@ export default function MatchPage() {
         x: finalDir * 350,
         opacity: 0,
         rotate: finalDir * 25,
-        transition: { duration: 0.3 }
+        transition: { duration: 0.3 },
       }
-    }
+    },
   }
 
   return (
     <div className="mc-page">
       <header className="mc-header">
-        <h1 className="mc-header-title">Party Discovery</h1>
+        <div>
+          <h1 className="mc-header-title">Party Discovery</h1>
+          <p className="mc-header-subtitle">{subtitleByStatus}</p>
+        </div>
         <button className="mc-filter-btn" aria-label="Filtros">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
             <line x1="3" y1="6" x2="21" y2="6" />
@@ -93,21 +99,24 @@ export default function MatchPage() {
 
       <main className="mc-deck">
         <AnimatePresence mode="popLayout" custom={exitDir}>
-          {status === 'loading' && (
+          {(status === 'idle' || status === 'loading') && (
             <motion.div key="loading" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
               <LoadingState />
             </motion.div>
           )}
+
           {status === 'error' && (
             <motion.div key="error" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
               <ErrorState message={error} onRetry={load} />
             </motion.div>
           )}
+
           {status === 'empty' && (
             <motion.div key="empty" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
               <EmptyState onCreateParty={() => navigate('/parties')} />
             </motion.div>
           )}
+
           {showCard && top && (
             <motion.div
               key={top.id}
@@ -137,7 +146,6 @@ export default function MatchPage() {
       />
 
       <CreatePartyBar onPress={() => navigate('/parties')} />
-
       <BottomNav />
     </div>
   )


### PR DESCRIPTION
# PR: simplificar matchmaking y corregir bloqueo de parties

## Resumen

Este PR corrige dos problemas principales:

1. El flujo de `/match` quedó demasiado complejo con la versión basada en cola y confirmaciones por websocket.
2. El endpoint de descubrimiento de parties podía quedar colgado por bloqueos transaccionales en backend.

La solución fue volver el matchmaking al modelo REST/Tinder más simple y estable, y mover el registro de actividad fuera de las transacciones en `parties`.

## Qué cambia

### Frontend

- Se restaura el flujo de matchmaking basado en REST:
  - `GET /parties/discover`
  - `POST /parties/:id/join`
- Se elimina del flujo principal de `/match` la lógica de:
  - cola
  - aceptar/rechazar por socket
  - espera de confirmaciones
  - redirección dependiente de `match:ready`
- Se mantienen los websockets donde sí agregan valor real:
  - chat en tiempo real
  - presencia
  - audio y archivos
- Se actualizan los tests de match para cubrir el flujo REST/Tinder.

### Backend

- Se corrige un problema de bloqueo en `PartiesService`.
- `logActivity()` y ciertos eventos que estaban ejecutándose dentro de transacciones ahora se disparan después del commit.
- Esto evita que `discover` y otras operaciones queden esperando por locks innecesarios.

## Motivación

El flujo anterior de matchmaking estaba agregando complejidad sin dar una mejora clara en UX. Además, cuando fallaba, la pantalla quedaba en estados ambiguos como:

- esperando confirmaciones
- acepté en ambos lados y no pasa nada
- spinner infinito buscando parties

Volver al modelo REST/Tinder hace el comportamiento más predecible, más fácil de probar y más simple de mantener.

## Archivos / áreas tocadas

### Commit 1

- `fix(match): restore REST-based party discovery`

Áreas principales:

- `frontend/src/hooks/useMatch.ts`
- `frontend/src/pages/MatchPage.tsx`
- `frontend/src/index.css`
- `frontend/src/hooks/useMatch.test.ts`
- `frontend/src/pages/MatchPage.test.tsx`

### Commit 2

- `fix(parties): avoid transaction deadlocks in activity logging`

Área principal:

- `backend/src/modules/parties/parties.service.ts`

## Cómo probar

### Match

1. Loguearse con un usuario válido.
2. Ir a `/match`.
3. Verificar que carguen cards reales de parties compatibles.
4. Descartar una party y confirmar que pase a la siguiente.
5. Aceptar una party y confirmar que:
   - haga join correctamente
   - redirija a la room/party

### Backend / parties

1. Crear o abrir una party existente.
2. Probar `discover` varias veces desde usuarios distintos.
3. Confirmar que no quede spinner infinito en `/match`.
4. Confirmar que un usuario pueda entrar a una party sin que se cuelgue la operación.

## Verificaciones realizadas

### Frontend

- `npm run test -- src/hooks/useMatch.test.ts src/pages/MatchPage.test.tsx`
- `npm run build`

### Backend

- `npm run build`

### Validación manual

- Se probó el flujo real de match.
- Al aceptar una party, la app redirige correctamente a la room.
- Se validó que `discover` vuelve a responder después del fix de transacciones.

## Impacto / compatibilidad

- No cambia el contrato REST de parties usado por el frontend.
- No toca migraciones.
- No cambia chat realtime.
- No cambia uploads de audio/archivos.
- Reduce complejidad funcional en matchmaking.

## Notas

- No se incluye `.env`.
- No se incluyen archivos de `backend/uploads/`.
- Quedaron fuera otros cambios no relacionados para mantener el PR enfocado.