### PR TITLE
fix: improve profile/dashboard nav spacing and restore chat audio realtime

### DIFF
--- a/frontend/src/hooks/useSocket.test.ts
+++ b/frontend/src/hooks/useSocket.test.ts
@@ -1,0 +1,33 @@
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const connectSocket = vi.fn(() => ({ connected: false }))
+const getSocket = vi.fn(() => ({ connected: false }))
+
+vi.mock('../services/socketService', () => ({
+  connectSocket,
+  getSocket,
+}))
+
+const useAuthStore = vi.fn()
+
+vi.mock('../store/authStore', () => ({
+  useAuthStore: () => useAuthStore(),
+}))
+
+describe('useSocket', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  it('does not connect during render when the user is not authenticated', async () => {
+    useAuthStore.mockReturnValue({ isAuthenticated: false })
+    const { useSocket } = await import('./useSocket')
+
+    renderHook(() => useSocket())
+
+    expect(connectSocket).not.toHaveBeenCalled()
+    expect(getSocket).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/hooks/useSocket.ts
+++ b/frontend/src/hooks/useSocket.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react'
 import type { Socket } from 'socket.io-client'
-import { connectSocket } from '../services/socketService'
+import { connectSocket, getSocket } from '../services/socketService'
 import { useAuthStore } from '../store/authStore'
 
 export function useSocket(): { socket: Socket } {
@@ -16,6 +16,6 @@ export function useSocket(): { socket: Socket } {
     }
   }, [isAuthenticated])
 
-  const socket = socketRef.current ?? connectSocket()
+  const socket = socketRef.current ?? getSocket()
   return { socket }
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -367,6 +367,12 @@ input, textarea, select { font-family: inherit; }
 .party-list-meta { font-size: 13px; color: var(--text-muted); display: flex; align-items: center; gap: 8px; }
 .party-list-arrow { color: var(--text-muted); font-size: 20px; }
 .subject-grid { display: flex; flex-direction: column; gap: 10px; }
+.dashboard-page {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding-bottom: 44px;
+}
 .subject-card {
   display: flex;
   align-items: center;
@@ -386,7 +392,7 @@ input, textarea, select { font-family: inherit; }
 .subject-card-meta { font-size: 12px; color: var(--text-muted); margin-top: 2px; }
 .subject-card-arrow { color: var(--text-muted); font-size: 20px; }
 
-.quick-actions { display: flex; gap: 12px; padding: 8px 0; }
+.quick-actions { display: flex; gap: 12px; padding: 8px 0 20px; }
 .quick-btn {
   flex: 1;
   display: flex;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1526,7 +1526,7 @@ input, textarea, select { font-family: inherit; }
   background: var(--bg-surface);
   border: 1px solid var(--border);
   border-radius: var(--radius-xl);
-  margin: 0 16px 72px;
+  margin: 0 16px 108px;
   padding: 16px;
   display: flex;
   flex-direction: column;

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -191,14 +191,23 @@ export default function ProfilePage() {
         )}
       </div>
 
-      <div style={{ marginTop: '32px', display: 'flex', gap: '10px' }}>
-        <Button variant="ghost" onClick={() => setIsEditing(true)} className="flex-1">
+      <h3 className="section-title" style={{ marginTop: '24px' }}>Cuenta</h3>
+      <div className="profile-actions-card">
+        <Button variant="secondary" onClick={() => setIsEditing(true)} className="w-full" size="lg">
           ✏️ Editar Perfil
         </Button>
-        <Button variant="danger" onClick={logout} className="flex-1" size="lg">
-          Salir
-        </Button>
+
+        <div className="profile-logout-panel">
+          <div className="profile-logout-copy">
+            <span className="profile-logout-title">Cerrar sesión</span>
+            <span className="profile-logout-text">Salí de tu cuenta en este dispositivo cuando quieras.</span>
+          </div>
+          <Button variant="danger" onClick={logout} className="profile-logout-button" size="md">
+            Salir
+          </Button>
+        </div>
       </div>
+      <div aria-hidden="true" style={{ height: '20px', flexShrink: 0 }} />
 
       {isEditing && (
         <EditProfileModal

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -27,17 +27,19 @@ const DashboardPage = () => {
 
   return (
     <MobileLayout>
-      <GreetingHeader user={user} />
-      <ActivePartyBanner party={activeParty} />
-      <SectionTitle>Mis Materias</SectionTitle>
-      {isLoading ? (
-        <div className="center-spinner">
-          <Spinner />
-        </div>
-      ) : (
-        <SubjectCardGrid subjects={subjects} />
-      )}
-      <QuickActions />
+      <div className="dashboard-page">
+        <GreetingHeader user={user} />
+        <ActivePartyBanner party={activeParty} />
+        <SectionTitle>Mis Materias</SectionTitle>
+        {isLoading ? (
+          <div className="center-spinner">
+            <Spinner />
+          </div>
+        ) : (
+          <SubjectCardGrid subjects={subjects} />
+        )}
+        <QuickActions />
+      </div>
     </MobileLayout>
   )
 }

--- a/frontend/src/services/socketService.test.ts
+++ b/frontend/src/services/socketService.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const connectMock = vi.fn()
+const fakeSocket = {
+  connected: false,
+  auth: {} as Record<string, string | null>,
+  connect: connectMock,
+  disconnect: vi.fn(),
+}
+
+vi.mock('socket.io-client', () => ({
+  io: vi.fn(() => fakeSocket),
+}))
+
+describe('socketService', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    localStorage.clear()
+    fakeSocket.connected = false
+    fakeSocket.auth = {}
+  })
+
+  it('refreshes auth token before connecting an existing socket', async () => {
+    localStorage.setItem('accessToken', 'old-token')
+    const service = await import('./socketService')
+
+    service.getSocket()
+
+    localStorage.setItem('accessToken', 'new-token')
+    service.connectSocket()
+
+    expect(fakeSocket.auth).toEqual({ token: 'new-token' })
+    expect(connectMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/services/socketService.ts
+++ b/frontend/src/services/socketService.ts
@@ -18,6 +18,7 @@ export function getSocket(): Socket {
 
 export function connectSocket(): Socket {
   const s = getSocket()
+  s.auth = { token: localStorage.getItem('accessToken') }
   if (!s.connected) s.connect()
   return s
 }


### PR DESCRIPTION
## Resumen

Este PR agrupa tres fixes puntuales sobre la base actual de `dev`:

- mejora el espaciado visual en Profile para que la sección Cuenta no choque con la barra inferior
- agrega espacio inferior en Dashboard para que las quick actions no queden pegadas a la navegación
- corrige el socket auth refresh para que audio/archivos vuelvan a aparecer en tiempo real después de login/logout o cambio de token

## Cambios

- `fix(profile): improve logout spacing above bottom nav`
- `fix(chat): refresh socket auth for realtime uploads`
- `fix(dashboard): add spacing above bottom nav`

## Verificación

- `frontend`: build OK
- tests nuevos:
  - `frontend/src/services/socketService.test.ts`
  - `frontend/src/hooks/useSocket.test.ts`
- validación manual del flujo visual en Profile y Dashboard
- validación del fix realtime para uploads de audio/chat

## Notas

- no incluye `.env`
- no incluye `backend/uploads/`
- rama actualizada con lo último de `origin/dev` antes de abrir el PR
