### PR TITLE
solve [Epic]: Modo Torneo entre Parties

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -24,6 +24,7 @@ import { SkillTreeModule } from './modules/skill-tree/skill-tree.module';
 import { AchievementsModule } from './modules/achievements/achievements.module';
 import { MatchmakingModule } from './gateways/matchmaking/matchmaking.module';
 import { SearchModule } from './modules/search/search.module';
+import { TournamentsModule } from './modules/tournaments/tournaments.module';
 
 @Module({
   imports: [
@@ -90,6 +91,7 @@ import { SearchModule } from './modules/search/search.module';
     AchievementsModule,
     MatchmakingModule,
     SearchModule,
+    TournamentsModule,
   ],
 })
 export class AppModule {}

--- a/backend/src/gateways/matchmaking/matchmaking.gateway.ts
+++ b/backend/src/gateways/matchmaking/matchmaking.gateway.ts
@@ -283,4 +283,44 @@ export class MatchmakingGateway
       }
     }
   }
+
+  // ─── Tournament Events ────────────────────────────────────────────────────────
+
+  @SubscribeMessage('tournament:join')
+  handleTournamentJoin(
+    @ConnectedSocket() socket: Socket,
+    @MessageBody() { tournamentId }: { tournamentId: string },
+  ) {
+    socket.join(`tournament:${tournamentId}`);
+    this.logger.log(`[WS] Súper-unión de socket ${socket.id} a torneo:${tournamentId}`);
+  }
+
+  @SubscribeMessage('tournament:leave')
+  handleTournamentLeave(
+    @ConnectedSocket() socket: Socket,
+    @MessageBody() { tournamentId }: { tournamentId: string },
+  ) {
+    socket.leave(`tournament:${tournamentId}`);
+    this.logger.log(`[WS] Salida de socket ${socket.id} de torneo:${tournamentId}`);
+  }
+
+  @OnEvent('tournament.started')
+  handleTournamentStarted(payload: { tournamentId: string; title: string; questId: string }) {
+    this.logger.log(`[WS] Torneo iniciado event: ${payload.tournamentId}`);
+    this.server.emit('tournament_started', payload);
+    this.server.to(`tournament:${payload.tournamentId}`).emit('tournament_started', payload);
+  }
+
+  @OnEvent('tournament.score_update')
+  handleTournamentScoreUpdate(payload: { tournamentId: string; scoreboard: any }) {
+    this.logger.log(`[WS] Torneo score update: ${payload.tournamentId}`);
+    this.server.to(`tournament:${payload.tournamentId}`).emit('tournament_score_update', payload);
+  }
+
+  @OnEvent('tournament.ended')
+  handleTournamentEnded(payload: { tournamentId: string; ranking: any }) {
+    this.logger.log(`[WS] Torneo finalizado event: ${payload.tournamentId}`);
+    this.server.emit('tournament_ended', payload);
+    this.server.to(`tournament:${payload.tournamentId}`).emit('tournament_ended', payload);
+  }
 }

--- a/backend/src/modules/quests/quests.service.ts
+++ b/backend/src/modules/quests/quests.service.ts
@@ -362,6 +362,12 @@ export class QuestsService {
       answeredQuestionIndices: [...answeredQuestionIndices, dto.questionIndex],
     });
 
+    this.eventEmitter.emit('quest.score_updated', {
+      questId: dto.questId,
+      userId,
+      score: attempt.score + xpEarned,
+    });
+
     return {
       attemptId: attempt.id,
       isCorrect,
@@ -403,6 +409,12 @@ export class QuestsService {
       status: 'completed',
       completedAt: new Date(),
       totalQuestions,
+    });
+
+    this.eventEmitter.emit('quest.score_updated', {
+      questId,
+      userId,
+      score: activeAttempt.score,
     });
 
     if (activeAttempt.attemptNumber === 1) {

--- a/backend/src/modules/tournaments/tournament-participant.entity.ts
+++ b/backend/src/modules/tournaments/tournament-participant.entity.ts
@@ -1,0 +1,41 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+  Unique,
+} from 'typeorm';
+import { Tournament } from './tournament.entity';
+import { Party } from '../parties/party.entity';
+
+@Entity('tournament_participants')
+@Unique(['tournamentId', 'partyId'])
+export class TournamentParticipant {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'tournament_id' })
+  @Index()
+  tournamentId: string;
+
+  @Column({ name: 'party_id' })
+  @Index()
+  partyId: string;
+
+  @ManyToOne(() => Tournament, (t) => t.participants, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'tournament_id' })
+  tournament: Tournament;
+
+  @ManyToOne(() => Party, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'party_id' })
+  party: Party;
+
+  @Column({ default: 0 })
+  score: number;
+
+  @CreateDateColumn({ name: 'joined_at', type: 'timestamptz' })
+  joinedAt: Date;
+}

--- a/backend/src/modules/tournaments/tournament.entity.ts
+++ b/backend/src/modules/tournaments/tournament.entity.ts
@@ -1,0 +1,64 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  OneToMany,
+  JoinColumn,
+  Index,
+} from 'typeorm';
+import { Quest } from '../quests/quest.entity';
+import { Party } from '../parties/party.entity';
+import { TournamentParticipant } from './tournament-participant.entity';
+
+export type TournamentStatus = 'pending' | 'active' | 'finished';
+
+@Entity('tournaments')
+export class Tournament {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ length: 200 })
+  title: string;
+
+  @Column({ name: 'quest_id' })
+  @Index()
+  questId: string;
+
+  @Column({ name: 'creator_party_id' })
+  @Index()
+  creatorPartyId: string;
+
+  @ManyToOne(() => Quest, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'quest_id' })
+  quest: Quest;
+
+  @ManyToOne(() => Party, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'creator_party_id' })
+  creatorParty: Party;
+
+  @Column({
+    type: 'enum',
+    enum: ['pending', 'active', 'finished'],
+    default: 'pending',
+  })
+  @Index()
+  status: TournamentStatus;
+
+  @Column({ name: 'starts_at', type: 'timestamptz' })
+  startsAt: Date;
+
+  @Column({ name: 'ends_at', type: 'timestamptz' })
+  endsAt: Date;
+
+  @OneToMany(() => TournamentParticipant, (tp) => tp.tournament, { cascade: true })
+  participants: TournamentParticipant[];
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at', type: 'timestamptz' })
+  updatedAt: Date;
+}

--- a/backend/src/modules/tournaments/tournaments.controller.ts
+++ b/backend/src/modules/tournaments/tournaments.controller.ts
@@ -1,0 +1,57 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Param,
+  UseGuards,
+  Request,
+} from '@nestjs/common';
+import { TournamentsService } from './tournaments.service';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+
+class CreateTournamentDto {
+  title: string;
+  questId: string;
+  startsAt: string;
+  endsAt: string;
+}
+
+@Controller('tournaments')
+@UseGuards(JwtAuthGuard)
+export class TournamentsController {
+  constructor(private readonly tournamentsService: TournamentsService) {}
+
+  @Post()
+  async create(@Body() dto: CreateTournamentDto, @Request() req: any) {
+    return this.tournamentsService.create(
+      {
+        title: dto.title,
+        questId: dto.questId,
+        startsAt: new Date(dto.startsAt),
+        endsAt: new Date(dto.endsAt),
+      },
+      req.user.id,
+    );
+  }
+
+  @Get()
+  async findAll() {
+    return this.tournamentsService.findAll();
+  }
+
+  @Get(':id')
+  async findById(@Param('id') id: string) {
+    return this.tournamentsService.findById(id);
+  }
+
+  @Post(':id/join')
+  async join(@Param('id') id: string, @Request() req: any) {
+    return this.tournamentsService.join(id, req.user.id);
+  }
+
+  @Get(':id/scoreboard')
+  async getScoreboard(@Param('id') id: string) {
+    return this.tournamentsService.getScoreboard(id);
+  }
+}

--- a/backend/src/modules/tournaments/tournaments.module.ts
+++ b/backend/src/modules/tournaments/tournaments.module.ts
@@ -1,0 +1,23 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { TournamentsService } from './tournaments.service';
+import { TournamentsController } from './tournaments.controller';
+import { Tournament } from './tournament.entity';
+import { TournamentParticipant } from './tournament-participant.entity';
+import { Party } from '../parties/party.entity';
+import { UsersModule } from '../users/users.module';
+import { PartiesModule } from '../parties/parties.module';
+import { QuestsModule } from '../quests/quests.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Tournament, TournamentParticipant, Party]),
+    UsersModule,
+    PartiesModule,
+    QuestsModule,
+  ],
+  controllers: [TournamentsController],
+  providers: [TournamentsService],
+  exports: [TournamentsService],
+})
+export class TournamentsModule {}

--- a/backend/src/modules/tournaments/tournaments.service.spec.ts
+++ b/backend/src/modules/tournaments/tournaments.service.spec.ts
@@ -1,0 +1,113 @@
+import { Test } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { Repository, DataSource } from 'typeorm';
+import { TournamentsService } from './tournaments.service';
+import { Tournament } from './tournament.entity';
+import { TournamentParticipant } from './tournament-participant.entity';
+import { Party } from '../parties/party.entity';
+import { UsersService } from '../users/users.service';
+import { PartiesService } from '../parties/parties.service';
+import { QuestsService } from '../quests/quests.service';
+
+describe('TournamentsService', () => {
+  let service: TournamentsService;
+  let tournamentRepo: jest.Mocked<Repository<Tournament>>;
+  let participantRepo: jest.Mocked<Repository<TournamentParticipant>>;
+  let partiesService: jest.Mocked<PartiesService>;
+  let questsService: jest.Mocked<QuestsService>;
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        TournamentsService,
+        {
+          provide: getRepositoryToken(Tournament),
+          useValue: {
+            create: jest.fn(),
+            save: jest.fn(),
+            findOne: jest.fn(),
+            find: jest.fn(),
+            update: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(TournamentParticipant),
+          useValue: {
+            create: jest.fn(),
+            save: jest.fn(),
+            find: jest.fn(),
+            update: jest.fn(),
+          },
+        },
+        { provide: getRepositoryToken(Party), useValue: {} },
+        {
+          provide: UsersService,
+          useValue: {
+            addXp: jest.fn(),
+            addCoins: jest.fn(),
+          },
+        },
+        {
+          provide: PartiesService,
+          useValue: {
+            findByUser: jest.fn(),
+            findById: jest.fn(),
+            addTextChatMessage: jest.fn(),
+            logActivity: jest.fn(),
+          },
+        },
+        {
+          provide: QuestsService,
+          useValue: {
+            findById: jest.fn(),
+          },
+        },
+        { provide: DataSource, useValue: {} },
+        { provide: EventEmitter2, useValue: { emit: jest.fn() } },
+      ],
+    }).compile();
+
+    service = moduleRef.get(TournamentsService);
+    tournamentRepo = moduleRef.get(getRepositoryToken(Tournament));
+    participantRepo = moduleRef.get(getRepositoryToken(TournamentParticipant));
+    partiesService = moduleRef.get(PartiesService);
+    questsService = moduleRef.get(QuestsService);
+  });
+
+  it('should create a tournament and register the host party', async () => {
+    const mockParty = { id: 'party-1', status: 'active' } as any;
+    const mockQuest = { id: 'quest-1', title: 'Algebra Quiz' } as any;
+    const mockTournament = { id: 'tournament-1', title: 'Math Cup', questId: 'quest-1' } as any;
+
+    partiesService.findByUser.mockResolvedValue([mockParty]);
+    questsService.findById.mockResolvedValue(mockQuest);
+    tournamentRepo.create.mockReturnValue(mockTournament);
+    tournamentRepo.save.mockResolvedValue(mockTournament);
+    
+    // findById mock
+    tournamentRepo.findOne.mockResolvedValue({
+      ...mockTournament,
+      participants: [{ partyId: 'party-1' } as any],
+    });
+
+    const result = await service.create(
+      {
+        title: 'Math Cup',
+        questId: 'quest-1',
+        startsAt: new Date(),
+        endsAt: new Date(),
+      },
+      'user-1',
+    );
+
+    expect(result).toBeDefined();
+    expect(result.id).toBe('tournament-1');
+    expect(partiesService.findByUser).toHaveBeenCalledWith('user-1');
+    expect(participantRepo.create).toHaveBeenCalledWith({
+      tournamentId: 'tournament-1',
+      partyId: 'party-1',
+    });
+    expect(participantRepo.save).toHaveBeenCalled();
+  });
+});

--- a/backend/src/modules/tournaments/tournaments.service.ts
+++ b/backend/src/modules/tournaments/tournaments.service.ts
@@ -1,0 +1,333 @@
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+  ConflictException,
+  Logger,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, DataSource, In, Between } from 'typeorm';
+import { EventEmitter2, OnEvent } from '@nestjs/event-emitter';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { Tournament } from './tournament.entity';
+import { TournamentParticipant } from './tournament-participant.entity';
+import { Party } from '../parties/party.entity';
+import { Quest } from '../quests/quest.entity';
+import { PlayerResult } from '../quests/player-result.entity';
+import { UsersService } from '../users/users.service';
+import { PartiesService } from '../parties/parties.service';
+import { QuestsService } from '../quests/quests.service';
+
+@Injectable()
+export class TournamentsService {
+  private readonly logger = new Logger(TournamentsService.name);
+
+  constructor(
+    @InjectRepository(Tournament)
+    private readonly tournamentRepo: Repository<Tournament>,
+    @InjectRepository(TournamentParticipant)
+    private readonly participantRepo: Repository<TournamentParticipant>,
+    @InjectRepository(Party)
+    private readonly partyRepo: Repository<Party>,
+    private readonly usersService: UsersService,
+    private readonly partiesService: PartiesService,
+    private readonly questsService: QuestsService,
+    private readonly dataSource: DataSource,
+    private readonly eventEmitter: EventEmitter2,
+  ) {}
+
+  async create(
+    dto: { title: string; questId: string; startsAt: Date; endsAt: Date },
+    userId: string,
+  ): Promise<Tournament> {
+    // 1. Obtener la party activa del usuario
+    const userParties = await this.partiesService.findByUser(userId);
+    const activeParty = userParties.find((p) => p.status === 'active' || p.status === 'forming');
+    if (!activeParty) {
+      throw new BadRequestException('Debés pertenecer a una party activa para crear un torneo');
+    }
+
+    // 2. Verificar que la quest existe
+    const quest = await this.questsService.findById(dto.questId);
+    if (!quest) {
+      throw new NotFoundException('Quest no encontrada');
+    }
+
+    // 3. Crear el torneo
+    const tournament = this.tournamentRepo.create({
+      title: dto.title,
+      questId: dto.questId,
+      creatorPartyId: activeParty.id,
+      startsAt: new Date(dto.startsAt),
+      endsAt: new Date(dto.endsAt),
+      status: 'pending',
+    });
+
+    const savedTournament = await this.tournamentRepo.save(tournament);
+
+    // 4. Agregar a la party creadora como primer participante
+    const participant = this.participantRepo.create({
+      tournamentId: savedTournament.id,
+      partyId: activeParty.id,
+    });
+    await this.participantRepo.save(participant);
+
+    // 5. Notificar en el chat de la party creadora
+    try {
+      await this.partiesService.addTextChatMessage(
+        activeParty.id,
+        userId,
+        `🏆 ¡Torneo "${dto.title}" creado con éxito! Iniciará a las ${new Date(dto.startsAt).toLocaleTimeString()}. Recuerden participar en la pestaña de Torneos.`,
+      );
+    } catch (err) {
+      this.logger.error(`Error enviando mensaje de chat: ${err.message}`);
+    }
+
+    return this.findById(savedTournament.id);
+  }
+
+  async findAll(): Promise<Tournament[]> {
+    return this.tournamentRepo.find({
+      relations: ['quest', 'participants', 'participants.party', 'participants.party.subject'],
+      order: { startsAt: 'DESC' },
+    });
+  }
+
+  async findById(id: string): Promise<Tournament> {
+    const tournament = await this.tournamentRepo.findOne({
+      where: { id },
+      relations: [
+        'quest',
+        'participants',
+        'participants.party',
+        'participants.party.subject',
+        'participants.party.members',
+        'participants.party.members.user',
+      ],
+    });
+    if (!tournament) {
+      throw new NotFoundException('Torneo no encontrado');
+    }
+    return tournament;
+  }
+
+  async join(tournamentId: string, userId: string): Promise<Tournament> {
+    const tournament = await this.findById(tournamentId);
+    if (tournament.status !== 'pending') {
+      throw new BadRequestException('El torneo ya se inició o ha finalizado');
+    }
+
+    const userParties = await this.partiesService.findByUser(userId);
+    const activeParty = userParties.find((p) => p.status === 'active' || p.status === 'forming');
+    if (!activeParty) {
+      throw new BadRequestException('Debés pertenecer a una party activa para unirte al torneo');
+    }
+
+    const alreadyJoined = tournament.participants.some((p) => p.partyId === activeParty.id);
+    if (alreadyJoined) {
+      throw new ConflictException('Tu party ya está inscripta en este torneo');
+    }
+
+    const participant = this.participantRepo.create({
+      tournamentId,
+      partyId: activeParty.id,
+    });
+    await this.participantRepo.save(participant);
+
+    // Notificar en el chat de la party que se une
+    try {
+      await this.partiesService.addTextChatMessage(
+        activeParty.id,
+        userId,
+        `🏆 ¡Nuestra party se ha unido al torneo "${tournament.title}"! Empieza pronto.`,
+      );
+    } catch (err) {
+      this.logger.error(`Error enviando mensaje de chat: ${err.message}`);
+    }
+
+    return this.findById(tournamentId);
+  }
+
+  async getScoreboard(tournamentId: string) {
+    const participants = await this.participantRepo.find({
+      where: { tournamentId },
+      relations: ['party', 'party.subject'],
+      order: { score: 'DESC' },
+    });
+
+    return participants.map((p, idx) => ({
+      rank: idx + 1,
+      partyId: p.partyId,
+      partyName: p.party.subject
+        ? `${p.party.subject.code} (Grupo ${p.partyId.slice(0, 4)})`
+        : `Grupo ${p.partyId.slice(0, 4)}`,
+      score: p.score,
+    }));
+  }
+
+  @OnEvent('quest.score_updated')
+  async handleQuestScoreUpdated(payload: {
+    questId: string;
+    userId: string;
+    score: number;
+  }) {
+    // Buscar torneo activo asociado a la quest
+    const tournament = await this.tournamentRepo.findOne({
+      where: { questId: payload.questId, status: 'active' },
+    });
+    if (!tournament) return;
+
+    // Buscar a qué party pertenece el usuario que está participando en el torneo
+    const participants = await this.participantRepo.find({
+      where: { tournamentId: tournament.id },
+      relations: ['party', 'party.members'],
+    });
+
+    const activeParticipant = participants.find((p) =>
+      p.party.members.some((m) => m.userId === payload.userId),
+    );
+
+    if (!activeParticipant) return;
+
+    // Recalcular puntaje acumulado de la party
+    // El puntaje de la party es la suma de los mejores puntajes de cada miembro durante el tiempo del torneo
+    const memberIds = activeParticipant.party.members.map((m) => m.userId);
+    const results = await this.dataSource.getRepository(PlayerResult).find({
+      where: {
+        questId: tournament.questId,
+        userId: In(memberIds),
+        createdAt: Between(tournament.startsAt, tournament.endsAt),
+      },
+    });
+
+    const userBestScores = new Map<string, number>();
+    for (const res of results) {
+      const currentBest = userBestScores.get(res.userId) ?? 0;
+      if (res.score > currentBest) {
+        userBestScores.set(res.userId, res.score);
+      }
+    }
+
+    let partyScore = 0;
+    for (const score of userBestScores.values()) {
+      partyScore += score;
+    }
+
+    // Actualizar score cacheado de la party
+    await this.participantRepo.update(activeParticipant.id, {
+      score: partyScore,
+    });
+
+    // Enviar actualización de scoreboard por WebSockets
+    const scoreboard = await this.getScoreboard(tournament.id);
+    this.eventEmitter.emit('tournament.score_update', {
+      tournamentId: tournament.id,
+      scoreboard,
+    });
+  }
+
+  @Cron(CronExpression.EVERY_10_SECONDS)
+  async handleTournamentSchedules() {
+    const now = new Date();
+
+    // 1. Iniciar torneos pendientes que llegaron a la fecha de inicio
+    const pendingTournaments = await this.tournamentRepo.find({
+      where: { status: 'pending' },
+      relations: ['participants', 'participants.party'],
+    });
+
+    for (const tournament of pendingTournaments) {
+      if (new Date(tournament.startsAt) <= now) {
+        await this.tournamentRepo.update(tournament.id, { status: 'active' });
+        this.eventEmitter.emit('tournament.started', {
+          tournamentId: tournament.id,
+          title: tournament.title,
+          questId: tournament.questId,
+        });
+
+        // Notificar en el chat de todas las parties participantes
+        for (const part of tournament.participants) {
+          try {
+            await this.partiesService.logActivity(
+              part.partyId,
+              'party_status_changed' as any, // Log activity generic
+              undefined,
+              `¡El torneo "${tournament.title}" ha comenzado! Tienen hasta las ${new Date(tournament.endsAt).toLocaleTimeString()} para resolver la quest.`,
+            );
+          } catch (err) {
+            this.logger.error(`Error enviando notificación de torneo iniciado: ${err.message}`);
+          }
+        }
+      }
+    }
+
+    // 2. Finalizar torneos activos que llegaron a la fecha de fin
+    const activeTournaments = await this.tournamentRepo.find({
+      where: { status: 'active' },
+      relations: ['participants', 'participants.party', 'participants.party.members'],
+    });
+
+    for (const tournament of activeTournaments) {
+      if (new Date(tournament.endsAt) <= now) {
+        await this.tournamentRepo.update(tournament.id, { status: 'finished' });
+
+        // Obtener ranking final
+        const scoreboard = await this.getScoreboard(tournament.id);
+
+        // Repartir recompensas a cada party según su ranking
+        for (let i = 0; i < scoreboard.length; i++) {
+          const entry = scoreboard[i];
+          const rank = i + 1;
+
+          // Recompensas por ranking:
+          // 1er lugar: 500 XP / 100 Coins
+          // 2do lugar: 300 XP / 50 Coins
+          // 3er lugar: 150 XP / 25 Coins
+          // Participación: 50 XP / 10 Coins
+          let xpAward = 50;
+          let coinsAward = 10;
+
+          if (rank === 1) {
+            xpAward = 500;
+            coinsAward = 100;
+          } else if (rank === 2) {
+            xpAward = 300;
+            coinsAward = 50;
+          } else if (rank === 3) {
+            xpAward = 150;
+            coinsAward = 25;
+          }
+
+          const participant = tournament.participants.find((p) => p.partyId === entry.partyId);
+          if (participant?.party?.members) {
+            for (const member of participant.party.members) {
+              try {
+                await this.usersService.addXp(member.userId, xpAward);
+                await this.usersService.addCoins(member.userId, coinsAward);
+              } catch (err) {
+                this.logger.error(`Error otorgando recompensa a usuario ${member.userId}: ${err.message}`);
+              }
+            }
+          }
+
+          // Registrar notificación en el chat de la party
+          try {
+            await this.partiesService.addTextChatMessage(
+              entry.partyId,
+              'SYSTEM' as any, // Notificación de sistema
+              `🏆 El torneo "${tournament.title}" ha finalizado. ¡Nuestra party quedó en el puesto #${rank} con ${entry.score} puntos! Recompensas obtenidas: +${xpAward} XP y +${coinsAward} monedas por miembro.`,
+            );
+          } catch (err) {
+            this.logger.error(`Error enviando notificación de torneo finalizado: ${err.message}`);
+          }
+        }
+
+        this.eventEmitter.emit('tournament.ended', {
+          tournamentId: tournament.id,
+          ranking: scoreboard,
+        });
+      }
+    }
+  }
+}
+

--- a/backend/src/modules/users/user.entity.ts
+++ b/backend/src/modules/users/user.entity.ts
@@ -28,6 +28,7 @@ export interface UserStats {
   currentStreak: number;
   longestStreak: number;
   lastPlayedAt: string | null;
+  coins: number;
 }
 
 export interface ActiveCosmetics {
@@ -101,6 +102,7 @@ export class User {
       currentStreak: 0,
       longestStreak: 0,
       lastPlayedAt: null,
+      coins: 0,
     },
   })
   stats: UserStats;

--- a/backend/src/modules/users/users.service.ts
+++ b/backend/src/modules/users/users.service.ts
@@ -460,6 +460,20 @@ export class UsersService {
       .execute();
   }
 
+  async addCoins(userId: string, coinsAmount: number): Promise<void> {
+    await this.userRepo
+      .createQueryBuilder()
+      .update()
+      .set({
+        stats: () => `jsonb_set(
+          stats,
+          '{coins}', to_jsonb(COALESCE((stats->>'coins')::int, 0) + ${coinsAmount})
+        )`,
+      })
+      .where('id = :id', { id: userId })
+      .execute();
+  }
+
   async updateStreak(userId: string): Promise<void> {
     await this.userRepo
       .createQueryBuilder()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,9 @@ import ProfilePage from './pages/ProfilePage'
 import JoinPartyPage from './pages/JoinPartyPage'
 import SkillTreePage from './pages/SkillTreePage'
 import LeaderboardPage from './pages/LeaderboardPage'
+import TournamentsPage from './pages/TournamentsPage'
+import TournamentLivePage from './pages/TournamentLivePage'
+import TournamentResultsPage from './pages/TournamentResultsPage'
 
 function App() {
   return (
@@ -35,6 +38,9 @@ function App() {
       <Route path="/quiz/:questId" element={<ProtectedRoute><QuizPage /></ProtectedRoute>} />
       <Route path="/join/:token" element={<ProtectedRoute><JoinPartyPage /></ProtectedRoute>} />
       <Route path="/subjects/:subjectId/skill-tree" element={<ProtectedRoute><SkillTreePage /></ProtectedRoute>} />
+      <Route path="/tournaments" element={<ProtectedRoute><TournamentsPage /></ProtectedRoute>} />
+      <Route path="/tournament/:id" element={<ProtectedRoute><TournamentLivePage /></ProtectedRoute>} />
+      <Route path="/tournament/:id/results" element={<ProtectedRoute><TournamentResultsPage /></ProtectedRoute>} />
 
       {/* 404 → auth */}
       <Route path="*" element={<Navigate to="/auth" replace />} />

--- a/frontend/src/components/PartyComponents.tsx
+++ b/frontend/src/components/PartyComponents.tsx
@@ -7,6 +7,7 @@ import type { Quest } from '../services/questService'
 import { Button, Spinner } from './UI'
 import { AvatarWithBorder } from './AvatarWithBorder'
 import { useNavigate } from 'react-router-dom'
+import { tournamentService } from '../services/tournamentService'
 export { ChatBox } from './party-chat/ChatBox'
 
 const API_ORIGIN = import.meta.env.VITE_API_URL ?? 'http://localhost:3000'
@@ -493,9 +494,138 @@ export function UploadNoteCard({ onUpload, isLoading }: UploadNoteCardProps) {
   )
 }
 
+function TournamentCreationModal({ quest, onClose }: { quest: Quest; onClose: () => void }) {
+  const [title, setTitle] = useState(`Torneo de ${quest.title}`)
+  const [delayMin, setDelayMin] = useState(2)
+  const [durationMin, setDurationMin] = useState(5)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState(false)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setIsLoading(true)
+    setError(null)
+
+    const startsAt = new Date(Date.now() + delayMin * 60 * 1000).toISOString()
+    const endsAt = new Date(Date.now() + (delayMin + durationMin) * 60 * 1000).toISOString()
+
+    try {
+      await tournamentService.create({
+        title,
+        questId: quest.id,
+        startsAt,
+        endsAt,
+      })
+      setSuccess(true)
+      setTimeout(() => {
+        onClose()
+      }, 1500)
+    } catch (err: any) {
+      setError(err.response?.data?.message || 'Error al crear el torneo')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <div
+      className="invite-overlay"
+      style={{ zIndex: 1000, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+      onClick={onClose}
+    >
+      <div
+        className="invite-sheet"
+        style={{
+          width: '90%',
+          maxWidth: '400px',
+          borderRadius: '24px',
+          background: 'var(--bg-surface)',
+          padding: '24px',
+          border: '1px solid var(--border)',
+          transform: 'none',
+          bottom: 'auto'
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="invite-title" style={{ fontSize: '18px', textAlign: 'center', marginBottom: '8px' }}>
+          🏆 Crear Torneo por Tiempo
+        </h2>
+        <p className="invite-sub" style={{ textAlign: 'center', marginBottom: '20px' }}>
+          Múltiples parties competirán resolviendo esta quest en simultáneo.
+        </p>
+
+        {success ? (
+          <div className="text-center py-6 text-emerald-400 font-bold">
+            ✓ ¡Torneo creado con éxito!
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+            <div className="input-group">
+              <label className="label">Título del Torneo</label>
+              <input
+                className="input"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder="Ej. Torneo de Álgebra..."
+                required
+              />
+            </div>
+
+            <div className="input-group">
+              <label className="label">¿Cuándo empieza? (Cuenta regresiva)</label>
+              <select
+                className="input"
+                value={delayMin}
+                onChange={(e) => setDelayMin(Number(e.target.value))}
+              >
+                <option value={1}>En 1 minuto</option>
+                <option value={2}>En 2 minutos</option>
+                <option value={5}>En 5 minutos</option>
+                <option value={10}>En 10 minutos</option>
+              </select>
+            </div>
+
+            <div className="input-group">
+              <label className="label">¿Cuánto dura la competencia?</label>
+              <select
+                className="input"
+                value={durationMin}
+                onChange={(e) => setDurationMin(Number(e.target.value))}
+              >
+                <option value={3}>3 minutos</option>
+                <option value={5}>5 minutos</option>
+                <option value={10}>10 minutos</option>
+                <option value={20}>20 minutos</option>
+                <option value={30}>30 minutos</option>
+              </select>
+            </div>
+
+            {error && (
+              <p style={{ color: 'var(--red)', fontSize: '13px', margin: 0, textAlign: 'center' }}>
+                {error}
+              </p>
+            )}
+
+            <div style={{ display: 'flex', gap: '10px', marginTop: '8px' }}>
+              <Button type="button" variant="ghost" className="flex-1" onClick={onClose}>
+                Cancelar
+              </Button>
+              <Button type="submit" variant="primary" className="flex-1" isLoading={isLoading}>
+                Crear ⚔️
+              </Button>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  )
+}
+
 // ─── QuestCard ───────────────────────────────────────────────────────────────
 export function QuestCard({ quest }: { quest: Quest }) {
   const navigate = useNavigate()
+  const [showModal, setShowModal] = useState(false)
   const questionCount = quest.questionCount ?? quest.questions?.length ?? 0
   const sourceLabel = quest.sourceType === 'pdf' || quest.sourcePdfUrl ? 'PDF adjunto' : 'Texto'
   const isGenerating = quest.status === 'generating' || quest.status === 'pending'
@@ -524,42 +654,73 @@ export function QuestCard({ quest }: { quest: Quest }) {
   }
 
   return (
-    <div
-      className="quest-card"
-      onClick={handleOpenQuest}
-      style={{ cursor: canPlay ? 'pointer' : 'default', opacity: isFailed ? 0.8 : 1 }}
-      aria-disabled={!canPlay}
-    >
-      <div className="quest-card-info">
-        <p className="quest-card-title">{quest.title}</p>
-        <p className="quest-card-meta">
-          {questionCount} preguntas
-          {` • ${sourceLabel}`}
-        </p>
-        {statusLabel && <p className="quest-card-link">{statusLabel}</p>}
-        {statusHint && <p className="text-small">{statusHint}</p>}
-        {quest.sourcePdfUrl && (
-          <a
-            className="quest-card-link"
-            href={new URL(quest.sourcePdfUrl, 'http://localhost:3000').toString()}
-            target="_blank"
-            rel="noreferrer"
-            onClick={(event) => event.stopPropagation()}
-          >
-            Ver PDF
-          </a>
-        )}
+    <>
+      <div
+        className="quest-card"
+        onClick={handleOpenQuest}
+        style={{ cursor: canPlay ? 'pointer' : 'default', opacity: isFailed ? 0.8 : 1 }}
+        aria-disabled={!canPlay}
+      >
+        <div className="quest-card-info">
+          <p className="quest-card-title">{quest.title}</p>
+          <p className="quest-card-meta">
+            {questionCount} preguntas
+            {` • ${sourceLabel}`}
+          </p>
+          {statusLabel && <p className="quest-card-link">{statusLabel}</p>}
+          {statusHint && <p className="text-small">{statusHint}</p>}
+          {quest.sourcePdfUrl && (
+            <a
+              className="quest-card-link"
+              href={new URL(quest.sourcePdfUrl, 'http://localhost:3000').toString()}
+              target="_blank"
+              rel="noreferrer"
+              onClick={(event) => event.stopPropagation()}
+            >
+              Ver PDF
+            </a>
+          )}
+          {canPlay && (
+            <button
+              className="quest-card-link"
+              style={{
+                marginTop: '8px',
+                background: 'rgba(124, 58, 237, 0.15)',
+                color: '#c084fc',
+                padding: '4px 8px',
+                borderRadius: '8px',
+                border: '1px solid rgba(124, 58, 237, 0.3)',
+                fontSize: '11px',
+                fontWeight: 'bold',
+                cursor: 'pointer',
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: '4px'
+              }}
+              onClick={(e) => {
+                e.stopPropagation()
+                setShowModal(true)
+              }}
+            >
+              🏆 Iniciar Torneo
+            </button>
+          )}
+        </div>
+        <span className={`quest-status quest-status-${quest.status}`}>
+          {isGenerating
+            ? '⏳'
+            : quest.status === 'active'
+              ? '▶'
+              : quest.status === 'failed'
+                ? '⚠️'
+                : '✅'}
+        </span>
       </div>
-      <span className={`quest-status quest-status-${quest.status}`}>
-        {isGenerating
-          ? '⏳'
-          : quest.status === 'active'
-            ? '▶'
-            : quest.status === 'failed'
-              ? '⚠️'
-              : '✅'}
-      </span>
-    </div>
+
+      {showModal && (
+        <TournamentCreationModal quest={quest} onClose={() => setShowModal(false)} />
+      )}
+    </>
   )
 }
 

--- a/frontend/src/pages/TournamentLivePage.tsx
+++ b/frontend/src/pages/TournamentLivePage.tsx
@@ -1,0 +1,211 @@
+import { useEffect, useState } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import { MobileLayout } from '../components/Layouts'
+import { Button, Spinner } from '../components/UI'
+import { useSocket } from '../hooks/useSocket'
+import { tournamentService, type Tournament, type ScoreboardEntry } from '../services/tournamentService'
+import { partyService } from '../services/partyService'
+
+const Countdown = ({ targetDate, onComplete }: { targetDate: string; onComplete?: () => void }) => {
+  const [timeLeft, setTimeLeft] = useState('')
+
+  useEffect(() => {
+    const calculateTime = () => {
+      const difference = new Date(targetDate).getTime() - Date.now()
+      if (difference <= 0) {
+        setTimeLeft('00:00')
+        onComplete?.()
+        return
+      }
+
+      const minutes = Math.floor((difference / 1000 / 60) % 60)
+      const seconds = Math.floor((difference / 1000) % 60)
+
+      setTimeLeft(
+        `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`
+      )
+    }
+
+    calculateTime()
+    const timer = setInterval(calculateTime, 1000)
+
+    return () => clearInterval(timer)
+  }, [targetDate, onComplete])
+
+  return <span className="font-mono text-xl text-red-500 font-extrabold tracking-wider">{timeLeft}</span>
+}
+
+export default function TournamentLivePage() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const { socket } = useSocket()
+  
+  const [tournament, setTournament] = useState<Tournament | null>(null)
+  const [scoreboard, setScoreboard] = useState<ScoreboardEntry[]>([])
+  const [myParty, setMyParty] = useState<any>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const initData = async () => {
+    if (!id) return
+    try {
+      const t = await tournamentService.getById(id)
+      setTournament(t)
+      
+      const scores = await tournamentService.getScoreboard(id)
+      setScoreboard(scores)
+      
+      const parties = await partyService.getMine()
+      const active = parties.find((p) => p.status === 'active' || p.status === 'forming')
+      setMyParty(active)
+    } catch (err) {
+      setError('Error al cargar la información del torneo')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    initData()
+  }, [id])
+
+  useEffect(() => {
+    if (!socket || !id) return
+
+    socket.emit('tournament:join', { tournamentId: id })
+
+    socket.on('tournament_score_update', (data: { tournamentId: string; scoreboard: ScoreboardEntry[] }) => {
+      if (data.tournamentId === id) {
+        setScoreboard(data.scoreboard)
+      }
+    })
+
+    socket.on('tournament_ended', (data: { tournamentId: string }) => {
+      if (data.tournamentId === id) {
+        navigate(`/tournament/${id}/results`)
+      }
+    })
+
+    return () => {
+      socket.emit('tournament:leave', { tournamentId: id })
+      socket.off('tournament_score_update')
+      socket.off('tournament_ended')
+    }
+  }, [socket, id])
+
+  if (isLoading) {
+    return (
+      <MobileLayout>
+        <div className="flex-1 flex items-center justify-center">
+          <Spinner />
+        </div>
+      </MobileLayout>
+    )
+  }
+
+  if (error || !tournament) {
+    return (
+      <MobileLayout>
+        <div className="p-4 flex flex-col gap-4">
+          <div className="p-4 bg-red-500/10 border border-red-500/20 text-red-500 rounded-xl text-center text-sm">
+            {error || 'Torneo no encontrado'}
+          </div>
+          <Button onClick={() => navigate('/tournaments')}>Volver a Torneos</Button>
+        </div>
+      </MobileLayout>
+    )
+  }
+
+  const isMyPartyParticipating = tournament.participants?.some((p) => p.partyId === myParty?.id)
+
+  return (
+    <MobileLayout>
+      <div className="p-4 flex flex-col gap-4 min-h-0">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <button
+              onClick={() => navigate('/tournaments')}
+              className="w-10 h-10 rounded-xl bg-[#13131f] border border-white/8 flex items-center justify-center text-white text-lg hover:bg-[#1a1a2e] transition-all cursor-pointer"
+            >
+              ←
+            </button>
+            <div>
+              <h1 className="text-base font-black text-white truncate max-w-[200px]">{tournament.title}</h1>
+              <p className="text-[#8888aa] text-[10px] uppercase font-bold tracking-wider">🔴 COMPETENCIA EN VIVO</p>
+            </div>
+          </div>
+
+          <div className="bg-red-500/10 border border-red-500/25 px-3 py-1.5 rounded-2xl flex flex-col items-center shrink-0">
+            <span className="text-[#ff5c5c] text-[8px] font-bold uppercase tracking-wider">Tiempo Restante</span>
+            <Countdown targetDate={tournament.endsAt} onComplete={() => navigate(`/tournament/${id}/results`)} />
+          </div>
+        </div>
+
+        {isMyPartyParticipating ? (
+          <div className="bg-gradient-to-br from-purple-950/20 to-indigo-950/20 border border-purple-500/30 p-4 rounded-3xl flex flex-col gap-3 relative overflow-hidden shrink-0">
+            <div className="flex justify-between items-start">
+              <div>
+                <h4 className="text-white font-extrabold text-sm">¡Tu Party está compitiendo!</h4>
+                <p className="text-[#a78bfa] text-[11px] mt-0.5">Resolvé la quest para acumular puntos.</p>
+              </div>
+              <span className="text-xl">⚡</span>
+            </div>
+            <Button
+              className="w-full bg-gradient-to-r from-purple-600 to-indigo-600 hover:from-purple-700 hover:to-indigo-700 text-xs py-2.5 font-bold shadow-[0_0_15px_rgba(124,58,237,0.5)]"
+              onClick={() => navigate(`/quiz/${tournament.questId}`)}
+            >
+              ⚔️ RESOLVER QUEST AHORA
+            </Button>
+          </div>
+        ) : (
+          <div className="bg-[#13131f] border border-white/5 p-4 rounded-3xl text-center text-xs text-[#8888aa] shrink-0">
+            Estás viendo este torneo en modo espectador ya que tu party no se inscribió.
+          </div>
+        )}
+
+        <div className="flex-1 flex flex-col gap-3 min-h-0 bg-[#13131f] border border-white/8 rounded-3xl p-4">
+          <h3 className="text-[#8888aa] text-xs font-bold uppercase tracking-wider">📊 Tabla de Posiciones</h3>
+          
+          <div className="flex-1 overflow-y-auto pr-1 flex flex-col gap-2">
+            {scoreboard.length === 0 ? (
+              <div className="text-center py-10 text-[#8888aa] text-xs">
+                No hay parties participando o aún nadie ha puntuado.
+              </div>
+            ) : (
+              scoreboard.map((entry, idx) => {
+                const isMyEntry = entry.partyId === myParty?.id
+                const medal = idx === 0 ? '🥇' : idx === 1 ? '🥈' : idx === 2 ? '🥉' : null
+                
+                return (
+                  <div
+                    key={entry.partyId}
+                    className={`flex items-center gap-3 p-3 rounded-2xl transition-all duration-300 border ${
+                      isMyEntry
+                        ? 'bg-purple-950/20 border-purple-500/35 shadow-[0_0_10px_rgba(124,58,237,0.15)]'
+                        : 'bg-[#1a1a2e]/50 border-white/5 hover:bg-[#1a1a2e]'
+                    }`}
+                  >
+                    <div className="w-6 text-center font-black text-sm text-[#8888aa]">
+                      {medal ? <span className="text-base">{medal}</span> : <span>#{entry.rank}</span>}
+                    </div>
+                    
+                    <div className="flex-1 min-w-0">
+                      <p className={`text-xs font-bold truncate ${isMyEntry ? 'text-purple-400' : 'text-white'}`}>
+                        {entry.partyName}
+                      </p>
+                      {isMyEntry && <p className="text-[9px] text-[#a78bfa] font-semibold">Tu Party</p>}
+                    </div>
+
+                    <div className="text-right shrink-0">
+                      <span className="text-sm font-black text-white">{entry.score} pts</span>
+                    </div>
+                  </div>
+                )
+              })
+            )}
+          </div>
+        </div>
+      </div>
+    </MobileLayout>
+  )
+}

--- a/frontend/src/pages/TournamentResultsPage.tsx
+++ b/frontend/src/pages/TournamentResultsPage.tsx
@@ -1,0 +1,217 @@
+import { useEffect, useState } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import { motion } from 'framer-motion'
+import { MobileLayout } from '../components/Layouts'
+import { Button, Spinner } from '../components/UI'
+import { tournamentService, type Tournament, type ScoreboardEntry } from '../services/tournamentService'
+import { partyService } from '../services/partyService'
+
+export default function TournamentResultsPage() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  
+  const [tournament, setTournament] = useState<Tournament | null>(null)
+  const [scoreboard, setScoreboard] = useState<ScoreboardEntry[]>([])
+  const [myParty, setMyParty] = useState<any>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const initData = async () => {
+      if (!id) return
+      try {
+        const t = await tournamentService.getById(id)
+        setTournament(t)
+        
+        const scores = await tournamentService.getScoreboard(id)
+        setScoreboard(scores)
+        
+        const parties = await partyService.getMine()
+        const active = parties.find((p) => p.status === 'active' || p.status === 'forming')
+        setMyParty(active)
+      } catch (err) {
+        setError('Error al cargar los resultados del torneo')
+      } finally {
+        setIsLoading(false)
+      }
+    }
+    initData()
+  }, [id])
+
+  if (isLoading) {
+    return (
+      <MobileLayout>
+        <div className="flex-1 flex items-center justify-center">
+          <Spinner />
+        </div>
+      </MobileLayout>
+    )
+  }
+
+  if (error || !tournament) {
+    return (
+      <MobileLayout>
+        <div className="p-4 flex flex-col gap-4">
+          <div className="p-4 bg-red-500/10 border border-red-500/20 text-red-500 rounded-xl text-center text-sm">
+            {error || 'Resultados no encontrados'}
+          </div>
+          <Button onClick={() => navigate('/tournaments')}>Volver a Torneos</Button>
+        </div>
+      </MobileLayout>
+    )
+  }
+
+  const firstPlace = scoreboard[0] || null
+  const secondPlace = scoreboard[1] || null
+  const thirdPlace = scoreboard[2] || null
+  const restEntries = scoreboard.slice(3)
+
+  // Calcular recompensa del usuario actual
+  const myPartyRank = scoreboard.findIndex((entry) => entry.partyId === myParty?.id) + 1
+  const isMyPartyParticipating = myPartyRank > 0
+
+  let xpReward = 0
+  let coinsReward = 0
+
+  if (isMyPartyParticipating) {
+    if (myPartyRank === 1) {
+      xpReward = 500
+      coinsReward = 100
+    } else if (myPartyRank === 2) {
+      xpReward = 300
+      coinsReward = 50
+    } else if (myPartyRank === 3) {
+      xpReward = 150
+      coinsReward = 25
+    } else {
+      xpReward = 50
+      coinsReward = 10
+    }
+  }
+
+  return (
+    <MobileLayout>
+      <div className="p-4 flex flex-col gap-4 min-h-0">
+        <div className="flex items-center gap-3">
+          <button
+            onClick={() => navigate('/tournaments')}
+            className="w-10 h-10 rounded-xl bg-[#13131f] border border-white/8 flex items-center justify-center text-white text-lg hover:bg-[#1a1a2e] transition-all cursor-pointer"
+          >
+            ←
+          </button>
+          <div>
+            <h1 className="text-base font-black text-white truncate max-w-[260px]">{tournament.title}</h1>
+            <p className="text-[#8888aa] text-[10px] uppercase font-bold tracking-wider">🏆 Resultados del Torneo</p>
+          </div>
+        </div>
+
+        {/* PODIO ANIMADO */}
+        <div className="flex items-end justify-center gap-3 pt-6 pb-2 shrink-0 border-b border-white/5">
+          {/* 2nd Place */}
+          {secondPlace && (
+            <motion.div
+              initial={{ y: 50, opacity: 0 }}
+              animate={{ y: 0, opacity: 1 }}
+              transition={{ delay: 0.4, type: 'spring', stiffness: 100 }}
+              className="flex flex-col items-center flex-1"
+            >
+              <span className="text-xl mb-1">🥈</span>
+              <span className="text-[10px] font-bold text-[#8888aa] truncate max-w-[80px]">{secondPlace.partyName}</span>
+              <span className="text-[9px] text-[#8888aa]">{secondPlace.score} pts</span>
+              <div className="w-full h-20 bg-gradient-to-t from-[#2a2a3e] to-[#3a3a5e] border-t border-white/10 rounded-t-xl mt-2 flex items-center justify-center shadow-lg">
+                <span className="text-white font-extrabold text-sm">#2</span>
+              </div>
+            </motion.div>
+          )}
+
+          {/* 1st Place */}
+          {firstPlace && (
+            <motion.div
+              initial={{ y: 70, opacity: 0 }}
+              animate={{ y: 0, opacity: 1 }}
+              transition={{ delay: 0.2, type: 'spring', stiffness: 100 }}
+              className="flex flex-col items-center flex-1 z-10"
+            >
+              <span className="text-3xl mb-1 filter drop-shadow-[0_0_8px_rgba(234,179,8,0.5)]">👑</span>
+              <span className="text-[11px] font-black text-yellow-400 truncate max-w-[90px]">{firstPlace.partyName}</span>
+              <span className="text-[10px] text-yellow-400 font-bold">{firstPlace.score} pts</span>
+              <div className="w-full h-28 bg-gradient-to-t from-[#4a3f1a] to-[#78350f] border-t border-yellow-500/30 rounded-t-2xl mt-2 flex items-center justify-center shadow-[0_0_15px_rgba(234,179,8,0.15)]">
+                <span className="text-yellow-400 font-black text-lg">#1</span>
+              </div>
+            </motion.div>
+          )}
+
+          {/* 3rd Place */}
+          {thirdPlace && (
+            <motion.div
+              initial={{ y: 40, opacity: 0 }}
+              animate={{ y: 0, opacity: 1 }}
+              transition={{ delay: 0.6, type: 'spring', stiffness: 100 }}
+              className="flex flex-col items-center flex-1"
+            >
+              <span className="text-xl mb-1">🥉</span>
+              <span className="text-[10px] font-bold text-[#b45309] truncate max-w-[80px]">{thirdPlace.partyName}</span>
+              <span className="text-[9px] text-[#b45309]">{thirdPlace.score} pts</span>
+              <div className="w-full h-14 bg-gradient-to-t from-[#271c19] to-[#451a03] border-t border-orange-500/10 rounded-t-xl mt-2 flex items-center justify-center shadow-lg">
+                <span className="text-orange-400 font-extrabold text-xs">#3</span>
+              </div>
+            </motion.div>
+          )}
+        </div>
+
+        {/* RECOMPENSAS OBTENIDAS */}
+        {isMyPartyParticipating ? (
+          <motion.div
+            initial={{ scale: 0.9, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            transition={{ delay: 0.8 }}
+            className="bg-gradient-to-br from-purple-950/30 to-indigo-950/30 border border-purple-500/40 p-4 rounded-3xl flex flex-col gap-2 items-center text-center shrink-0"
+          >
+            <span className="text-[#a78bfa] text-[10px] font-bold uppercase tracking-widest">Recompensa Obtenida</span>
+            <h4 className="text-white font-extrabold text-sm">Puesto #{myPartyRank} en el Podio</h4>
+            
+            <div className="flex gap-4 mt-1">
+              <div className="bg-purple-500/15 border border-purple-500/30 px-3 py-2 rounded-2xl flex items-center gap-1.5 shadow-lg">
+                <span className="text-base">✨</span>
+                <span className="text-white font-black text-xs">+{xpReward} XP</span>
+              </div>
+              <div className="bg-yellow-500/15 border border-yellow-500/30 px-3 py-2 rounded-2xl flex items-center gap-1.5 shadow-lg">
+                <span className="text-base">🪙</span>
+                <span className="text-white font-black text-xs">+{coinsReward} Monedas</span>
+              </div>
+            </div>
+          </motion.div>
+        ) : (
+          <div className="bg-[#13131f] border border-white/5 p-4 rounded-3xl text-center text-xs text-[#8888aa] shrink-0">
+            No participaste en este torneo. ¡Prepárate para la próxima!
+          </div>
+        )}
+
+        {/* HISTORIAL RESTO DE POSICIONES */}
+        {restEntries.length > 0 && (
+          <div className="flex-1 flex flex-col gap-2.5 min-h-0 bg-[#13131f] border border-white/8 rounded-3xl p-4">
+            <h3 className="text-[#8888aa] text-xs font-bold uppercase tracking-wider">Otras posiciones</h3>
+            <div className="flex-1 overflow-y-auto pr-1 flex flex-col gap-2">
+              {restEntries.map((entry) => (
+                <div
+                  key={entry.partyId}
+                  className="flex items-center justify-between p-2.5 bg-[#1a1a2e]/40 border border-white/5 rounded-xl text-xs"
+                >
+                  <div className="flex items-center gap-3">
+                    <span className="text-[#8888aa] font-bold w-6">#{entry.rank}</span>
+                    <span className="text-white font-semibold">{entry.partyName}</span>
+                  </div>
+                  <span className="text-white font-bold">{entry.score} pts</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <Button className="w-full text-xs font-bold py-2.5 mt-2" onClick={() => navigate('/tournaments')}>
+          Volver a Torneos
+        </Button>
+      </div>
+    </MobileLayout>
+  )
+}

--- a/frontend/src/pages/TournamentsPage.tsx
+++ b/frontend/src/pages/TournamentsPage.tsx
@@ -1,0 +1,227 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { MobileLayout } from '../components/Layouts'
+import { Button, Spinner } from '../components/UI'
+import { tournamentService, type Tournament } from '../services/tournamentService'
+import { partyService } from '../services/partyService'
+
+const Countdown = ({ targetDate, onComplete }: { targetDate: string; onComplete?: () => void }) => {
+  const [timeLeft, setTimeLeft] = useState('')
+
+  useEffect(() => {
+    const calculateTime = () => {
+      const difference = new Date(targetDate).getTime() - Date.now()
+      if (difference <= 0) {
+        setTimeLeft('00:00:00')
+        onComplete?.()
+        return
+      }
+
+      const hours = Math.floor((difference / (1000 * 60 * 60)) % 24)
+      const minutes = Math.floor((difference / 1000 / 60) % 60)
+      const seconds = Math.floor((difference / 1000) % 60)
+
+      setTimeLeft(
+        `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`
+      )
+    }
+
+    calculateTime()
+    const timer = setInterval(calculateTime, 1000)
+
+    return () => clearInterval(timer)
+  }, [targetDate, onComplete])
+
+  return <span className="font-mono text-purple-400 font-bold">{timeLeft}</span>
+}
+
+export default function TournamentsPage() {
+  const navigate = useNavigate()
+  const [tournaments, setTournaments] = useState<Tournament[]>([])
+  const [activeParty, setActiveParty] = useState<any>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchTournaments = async () => {
+    try {
+      const list = await tournamentService.getAll()
+      setTournaments(list)
+    } catch (err) {
+      setError('Error al cargar la lista de torneos')
+    }
+  }
+
+  useEffect(() => {
+    const init = async () => {
+      setIsLoading(true)
+      try {
+        await fetchTournaments()
+        const parties = await partyService.getMine()
+        const active = parties.find((p) => p.status === 'active' || p.status === 'forming')
+        setActiveParty(active)
+      } catch (err) {
+        setError('Error al inicializar la página')
+      } finally {
+        setIsLoading(false)
+      }
+    }
+    init()
+  }, [])
+
+  const handleJoin = async (tournamentId: string) => {
+    try {
+      await tournamentService.join(tournamentId)
+      await fetchTournaments()
+    } catch (err: any) {
+      alert(err.response?.data?.message || 'Error al unirse al torneo')
+    }
+  }
+
+  return (
+    <MobileLayout>
+      <div className="p-4 flex flex-col gap-4 min-h-0">
+        <div className="flex items-center gap-3">
+          <button
+            onClick={() => navigate('/dashboard')}
+            className="w-10 h-10 rounded-xl bg-[#13131f] border border-white/8 flex items-center justify-center text-white text-lg hover:bg-[#1a1a2e] transition-all cursor-pointer"
+          >
+            ←
+          </button>
+          <div>
+            <h1 className="text-xl font-black text-white">🏆 Torneos Globales</h1>
+            <p className="text-[#8888aa] text-xs">Competí con tu party resolviendo quests en tiempo real</p>
+          </div>
+        </div>
+
+        {isLoading ? (
+          <div className="flex-1 flex items-center justify-center py-20">
+            <Spinner />
+          </div>
+        ) : error ? (
+          <div className="p-4 bg-red-500/10 border border-red-500/20 text-red-500 rounded-xl text-center text-sm">
+            {error}
+          </div>
+        ) : tournaments.length === 0 ? (
+          <div className="flex-1 flex flex-col items-center justify-center py-20 text-center">
+            <span className="text-5xl mb-4">🏆</span>
+            <h3 className="text-white font-bold text-sm">No hay torneos creados</h3>
+            <p className="text-[#8888aa] text-xs max-w-[280px] mt-1">
+              Podés iniciar un torneo con una quest de tu materia desde el chat de tu party.
+            </p>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-3 overflow-y-auto pr-1">
+            {tournaments.map((t) => {
+              const hasJoined = t.participants?.some((p) => p.partyId === activeParty?.id)
+              const participantCount = t.participants?.length ?? 0
+
+              return (
+                <div
+                  key={t.id}
+                  className="bg-[#13131f] border border-white/8 rounded-2xl p-4 flex flex-col gap-3 hover:border-purple-500/30 transition-all duration-300 relative overflow-hidden group"
+                >
+                  {t.status === 'active' && (
+                    <div className="absolute top-0 right-0 bg-[#7c3aed] text-white text-[9px] font-bold uppercase tracking-wider px-3 py-1 rounded-bl-xl shadow-lg">
+                      🔥 ACTIVO
+                    </div>
+                  )}
+                  {t.status === 'finished' && (
+                    <div className="absolute top-0 right-0 bg-[#3b3b4f] text-[#8888aa] text-[9px] font-bold uppercase tracking-wider px-3 py-1 rounded-bl-xl">
+                      ✓ TERMINADO
+                    </div>
+                  )}
+
+                  <div className="flex flex-col gap-0.5">
+                    <h3 className="text-white font-bold text-base truncate pr-16">{t.title}</h3>
+                    <p className="text-[#8888aa] text-[11px]">
+                      Quest: <span className="text-purple-400 font-semibold">{t.quest?.title ?? 'Quest generada'}</span>
+                    </p>
+                  </div>
+
+                  <div className="flex items-center justify-between text-xs py-1.5 border-y border-white/5">
+                    <div className="flex flex-col">
+                      <span className="text-[#666688] text-[9px] uppercase font-bold tracking-wider">Participantes</span>
+                      <span className="text-white font-semibold mt-0.5">👥 {participantCount} Partys</span>
+                    </div>
+
+                    <div className="flex flex-col text-right">
+                      {t.status === 'pending' && (
+                        <>
+                          <span className="text-[#666688] text-[9px] uppercase font-bold tracking-wider">Inicia en</span>
+                          <Countdown targetDate={t.startsAt} onComplete={fetchTournaments} />
+                        </>
+                      )}
+                      {t.status === 'active' && (
+                        <>
+                          <span className="text-red-400 text-[9px] uppercase font-bold tracking-wider animate-pulse">Termina en</span>
+                          <Countdown targetDate={t.endsAt} onComplete={fetchTournaments} />
+                        </>
+                      )}
+                      {t.status === 'finished' && (
+                        <>
+                          <span className="text-[#666688] text-[9px] uppercase font-bold tracking-wider">Estado</span>
+                          <span className="text-[#8888aa] font-semibold mt-0.5">Finalizado</span>
+                        </>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="flex gap-2">
+                    {t.status === 'pending' && (
+                      <>
+                        {hasJoined ? (
+                          <div className="w-full text-center py-2.5 text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 rounded-xl text-xs font-bold flex items-center justify-center gap-1.5">
+                            ✓ ¡Tu Party ya está inscripta!
+                          </div>
+                        ) : activeParty ? (
+                          <Button className="w-full text-xs" onClick={() => handleJoin(t.id)}>
+                            ⚔️ Unirse con mi Party
+                          </Button>
+                        ) : (
+                          <div className="w-full text-center py-2.5 text-[#8888aa] bg-[#1a1a2e] border border-white/5 rounded-xl text-xs font-semibold">
+                            Debés estar en una party para unirte
+                          </div>
+                        )}
+                      </>
+                    )}
+
+                    {t.status === 'active' && (
+                      <>
+                        {hasJoined ? (
+                          <Button
+                            className="w-full text-xs bg-gradient-to-r from-purple-600 to-indigo-600 hover:from-purple-700 hover:to-indigo-700"
+                            onClick={() => navigate(`/tournament/${t.id}`)}
+                          >
+                            ⚡ Ver Scoreboard y Jugar
+                          </Button>
+                        ) : (
+                          <Button
+                            variant="secondary"
+                            className="w-full text-xs"
+                            onClick={() => navigate(`/tournament/${t.id}`)}
+                          >
+                            👁️ Ver Scoreboard en Vivo
+                          </Button>
+                        )}
+                      </>
+                    )}
+
+                    {t.status === 'finished' && (
+                      <Button
+                        variant="secondary"
+                        className="w-full text-xs"
+                        onClick={() => navigate(`/tournament/${t.id}/results`)}
+                      >
+                        🏆 Ver Resultados Finales
+                      </Button>
+                    )}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </div>
+    </MobileLayout>
+  )
+}

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -13,6 +13,7 @@ import { usePartyStore } from '../store/partyStore'
 import { useUserSubjects } from '../hooks/useUserSubjects'
 import { partyService } from '../services/partyService'
 import { userService, type RecommendedQuestDto, type LeaderboardEntry, type Subject } from '../services/userService'
+import { tournamentService } from '../services/tournamentService'
 import { searchService, type GlobalSearchResponseDto } from '../services/searchService'
 import { getLeague, DEFAULT_ELO } from '../utils/leagues'
 
@@ -140,6 +141,10 @@ const DashboardPage = () => {
   const { subjects, isLoading: isSubjectsLoading } = useUserSubjects()
   const { activeParty, setActiveParty } = usePartyStore()
 
+  // Tournaments state
+  const [tournaments, setTournaments] = useState<any[]>([])
+  const [isTournamentsLoading, setIsTournamentsLoading] = useState(false)
+
   // 1. Quests para hoy state
   const [questsToday, setQuestsToday] = useState<RecommendedQuestDto[]>([])
   const [isQuestsTodayLoading, setIsQuestsTodayLoading] = useState(false)
@@ -165,6 +170,21 @@ const DashboardPage = () => {
       setActiveParty(active)
     }).catch(() => {})
   }, [setActiveParty])
+
+  // Cargar torneos
+  useEffect(() => {
+    setIsTournamentsLoading(true)
+    tournamentService
+      .getAll()
+      .then((data) => {
+        const activeOrPending = data.filter((t) => t.status === 'active' || t.status === 'pending')
+        setTournaments(activeOrPending.slice(0, 2))
+      })
+      .catch(() => {})
+      .finally(() => {
+        setIsTournamentsLoading(false)
+      })
+  }, [])
 
   // Cargar Quests para hoy
   useEffect(() => {
@@ -403,6 +423,58 @@ const DashboardPage = () => {
         </div>
 
         <ActivePartyBanner party={activeParty} />
+
+        {/* Sección de Torneos */}
+        <div className="flex justify-between items-center mt-2 shrink-0">
+          <SectionTitle>🏆 Torneos Activos y Próximos</SectionTitle>
+          <Button
+            variant="ghost"
+            size="sm"
+            style={{ padding: '4px 8px', fontSize: '11px', fontWeight: 'bold', textTransform: 'uppercase' }}
+            onClick={() => navigate('/tournaments')}
+          >
+            Ver todos →
+          </Button>
+        </div>
+
+        {isTournamentsLoading ? (
+          <div style={{ display: 'flex', justifyContent: 'center', padding: '16px' }}><Spinner /></div>
+        ) : tournaments.length === 0 ? (
+          <div className="empty-state" style={{ padding: '16px', textAlign: 'center', background: '#13131f', borderRadius: '16px', border: '1px solid rgba(255,255,255,0.05)' }}>
+            <p className="empty-sub" style={{ margin: 0, fontSize: '11px', color: '#8888aa' }}>No hay torneos activos en este momento.</p>
+          </div>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+            {tournaments.map((t) => (
+              <div
+                key={t.id}
+                onClick={() => navigate(t.status === 'finished' ? `/tournament/${t.id}/results` : `/tournament/${t.id}`)}
+                className="flex items-center justify-between p-3 rounded-2xl bg-gradient-to-r from-[#13131f] to-[#1a1a2e] border border-white/5 hover:border-purple-500/30 transition-all cursor-pointer"
+              >
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '2px', minWidth: 0 }}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                    <span style={{
+                      fontSize: '9px',
+                      fontWeight: 'bold',
+                      padding: '2px 6px',
+                      borderRadius: '6px',
+                      background: t.status === 'active' ? 'rgba(239, 68, 68, 0.15)' : 'rgba(124, 58, 237, 0.15)',
+                      color: t.status === 'active' ? '#ef4444' : '#a78bfa',
+                      textTransform: 'uppercase'
+                    }}>
+                      {t.status === 'active' ? 'En Vivo' : 'Próximo'}
+                    </span>
+                    <span className="text-white font-extrabold text-xs truncate max-w-[180px]">{t.title}</span>
+                  </div>
+                  <span style={{ fontSize: '10px', color: '#8888aa' }}>
+                    Quest: {t.quest?.title ?? 'Quest del Torneo'}
+                  </span>
+                </div>
+                <span className="text-[#a78bfa] text-xs font-bold shrink-0">Ver →</span>
+              </div>
+            ))}
+          </div>
+        )}
 
         {/* 1. Quests para hoy */}
         <SectionTitle>Quests para hoy</SectionTitle>

--- a/frontend/src/services/tournamentService.ts
+++ b/frontend/src/services/tournamentService.ts
@@ -1,0 +1,77 @@
+import { api } from './api'
+
+export interface TournamentQuest {
+  id: string
+  title: string
+}
+
+export interface TournamentParticipantParty {
+  id: string
+  subject?: {
+    id: string
+    name: string
+    code: string
+  }
+}
+
+export interface TournamentParticipant {
+  id: string
+  tournamentId: string
+  partyId: string
+  score: number
+  joinedAt: string
+  party: TournamentParticipantParty
+}
+
+export interface Tournament {
+  id: string
+  title: string
+  questId: string
+  creatorPartyId: string
+  status: 'pending' | 'active' | 'finished'
+  startsAt: string
+  endsAt: string
+  createdAt: string
+  updatedAt: string
+  quest?: TournamentQuest
+  participants?: TournamentParticipant[]
+}
+
+export interface ScoreboardEntry {
+  rank: number
+  partyId: string
+  partyName: string
+  score: number
+}
+
+export const tournamentService = {
+  async getAll(): Promise<Tournament[]> {
+    const { data } = await api.get<Tournament[]>('/tournaments')
+    return data
+  },
+
+  async getById(id: string): Promise<Tournament> {
+    const { data } = await api.get<Tournament>(`/tournaments/${id}`)
+    return data
+  },
+
+  async create(payload: {
+    title: string
+    questId: string
+    startsAt: string
+    endsAt: string
+  }): Promise<Tournament> {
+    const { data } = await api.post<Tournament>('/tournaments', payload)
+    return data
+  },
+
+  async join(id: string): Promise<Tournament> {
+    const { data } = await api.post<Tournament>(`/tournaments/${id}/join`)
+    return data
+  },
+
+  async getScoreboard(id: string): Promise<ScoreboardEntry[]> {
+    const { data } = await api.get<ScoreboardEntry[]>(`/tournaments/${id}/scoreboard`)
+    return data
+  },
+}


### PR DESCRIPTION
# Feat: Modo de Torneo por Tiempo Limitado (Competencia Multicrupo)

Este PR implementa el modo de torneos sincronizados por tiempo limitado. Ahora, múltiples parties (grupos) pueden competir resolviendo la misma quest en tiempo real, actualizando sus puntajes en vivo vía WebSockets y obteniendo recompensas (XP y Monedas) al finalizar.

---

## 🚀 Cambios Implementados

### 🖥️ Backend (NestJS + TypeORM + PostgreSQL + WebSockets)
- **Nuevas Entidades**: 
  - `Tournament`: almacena quest vinculada, estado (`pending`, `active`, `finished`) y rango de tiempo (`startsAt`/`endsAt`).
  - `TournamentParticipant`: relación de parties competidoras y caché de scores acumulados.
- **Sistema de Monedas (Coins)**:
  - Añadido el campo `coins` en las estadísticas del usuario (`UserStats`).
  - Implementado el método `addCoins` en `UsersService` para la entrega de premios.
- **Lógica de Sincronización (Cron Job)**:
  - Tarea programada cada 10 segundos para inicializar torneos entrantes y cerrar torneos finalizados.
  - Distribución automatizada de XP y Monedas por rango de podio.
- **WebSockets**:
  - Evento `tournament_started` para notificar el inicio a las parties.
  - Evento `tournament_score_update` para actualizar la tabla de posiciones en vivo.
  - Evento `tournament_ended` para marcar el final y redirigir a los resultados.
  - Mensajes de estado integrados y emitidos en el chat grupal de las parties.

### 🎨 Frontend (React + Vite + Framer Motion)
- **Creación desde Chat**: Botón de *"🏆 Iniciar Torneo"* integrado en las tarjetas de quests listas en la Party Room (abre modal de configuración).
- **Dashboard**: Sección destacada Glassmorphism con torneos activos y próximos de la plataforma.
- **Listado global (`/tournaments`)**: Countdown en vivo para torneos próximos e inscripción rápida de tu party.
- **Scoreboard en Vivo (`/tournament/:id`)**: Tabla interactiva de posiciones reordenada en tiempo real mediante WebSocket.
- **Resultados y Podio (`/tournament/:id/results`)**: Podio 3D animado con Framer Motion y detalle de recompensas obtenidas (+XP y +Coins).

---

## ⚙️ Funcionamiento y Flujo

1. **Creación**: Un usuario inicia un torneo desde una quest en la Party Room, fijando hora de inicio y fin. Su party se une automáticamente.
2. **Unirse**: Otras parties pueden ver el torneo en su Dashboard o la lista de Torneos e inscribirse antes de que comience.
3. **Inicio**: Al llegar a la hora de inicio, se notifica vía sockets y los jugadores de las parties participantes pueden entrar a jugar.
4. **En Vivo**: A medida que los jugadores resuelven la quest, la party suma puntos (suma del mejor puntaje por miembro) y el scoreboard se actualiza en vivo.
5. **Fin**: Al finalizar el tiempo, se congela el ranking, se añaden los premios al perfil del usuario y se despliega la pantalla de resultados con el podio.

### 🎁 Tabla de Recompensas
| Puesto | XP otorgada | Monedas (Coins) |
| :---: | :---: | :---: |
| **🥇 1º Puesto** | +500 XP | +100 Coins |
| **🥈 2º Puesto** | +300 XP | +50 Coins |
| **🥉 3º Puesto** | +150 XP | +25 Coins |
| **🎖️ Participación** | +50 XP | +10 Coins |

---

## 🧪 Plan de Verificación

### 1. Pruebas Unitarias (Backend)
Se agregaron specs de cobertura para la creación, unión, scheduler y scoreboard:
```bash
cd backend
pnpm run test
