### PR TITLE
feat(frontend): redesign party Miembros tab as single-line gameplay rows

Replace the dead legacy CSS classes in MemberList with Tailwind. Each
member is now one compact line: avatar with an online/offline presence
dot, name with a gold leader crown and an accent title chip, and a gold
XP pill, plus a leader-only kick action. The invite button, privacy
toggle and leave/close actions are styled to match.

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="description" content="StudyQuest — Estudia, compite y gana con tu party universitaria" />
     <title>StudyQuest ⚡</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/frontend/src/components/Layouts.tsx
+++ b/frontend/src/components/Layouts.tsx
@@ -7,8 +7,8 @@ interface Props {
 
 export function MobileLayout({ children }: Props) {
   return (
-    <div className="w-full max-w-[480px] mx-auto self-center h-dvh flex flex-col bg-base overflow-hidden">
-      <main className="flex-1 flex flex-col gap-3 min-h-0 overflow-y-auto overflow-x-hidden pb-6">{children}</main>
+    <div className="w-full max-w-[480px] mx-auto self-center h-dvh flex flex-col bg-base overflow-hidden pt-[env(safe-area-inset-top)]">
+      <main className="flex-1 flex flex-col gap-3 min-h-0 overflow-y-auto overflow-x-hidden px-4 pb-6">{children}</main>
       <BottomNav />
     </div>
   )

--- a/frontend/src/components/PartyComponents.tsx
+++ b/frontend/src/components/PartyComponents.tsx
@@ -122,9 +122,9 @@ export function MemberList({ members, partyId, isPrivate, currentUserId, onVisib
 
   return (
     <>
-      <div className="member-list">
+      <div className="flex flex-col gap-2">
         <button
-          className="invite-btn"
+          className="flex items-center justify-center gap-2 w-full px-4 py-3 rounded-xl bg-accent/10 border border-accent/30 text-accent-light font-semibold text-sm hover:bg-accent/20 transition-colors"
           onClick={() => setShowInvite(true)}
         >
           <span>🔗</span>
@@ -132,29 +132,33 @@ export function MemberList({ members, partyId, isPrivate, currentUserId, onVisib
         </button>
 
         {isLeader && (
-          <div className="input-group" style={{ flexDirection: 'row', alignItems: 'center', gap: '8px', cursor: 'pointer', background: 'var(--bg-surface)', padding: '12px', borderRadius: 'var(--radius-lg)', border: '1px solid var(--border)', marginTop: '8px' }} onClick={() => onVisibilityChange(!isPrivate)}>
-            <input 
-              type="checkbox" 
-              checked={isPrivate} 
+          <label className="flex items-center gap-3 cursor-pointer bg-surface p-3 rounded-xl border border-edge">
+            <input
+              type="checkbox"
+              checked={isPrivate}
               onChange={() => onVisibilityChange(!isPrivate)}
-              style={{ width: '18px', height: '18px', cursor: 'pointer' }}
+              className="w-[18px] h-[18px] cursor-pointer accent-[var(--accent)]"
             />
-            <div style={{ display: 'flex', flexDirection: 'column' }}>
-              <span style={{ fontSize: '15px', fontWeight: 600 }}>Party Privada 🔒</span>
-              <span style={{ fontSize: '12px', color: 'var(--text-secondary)' }}>Ocultar la party en Matchmaking.</span>
+            <div className="flex flex-col">
+              <span className="text-[15px] font-semibold text-primary">Party Privada 🔒</span>
+              <span className="text-xs text-secondary">Ocultar la party en Matchmaking.</span>
             </div>
-          </div>
+          </label>
         )}
 
         {members.map((m) => {
           const avatarUrl = resolveAssetUrl(m.user.avatarUrl)
+          const isLeaderRow = m.role === 'leader'
+          const title = m.user.activeCosmetics?.titleText
 
           return (
           <div
             key={m.id}
-            className={`member-item${m.role === 'leader' ? ' member-item-leader' : ''}`}
+            className={`flex items-center gap-2.5 px-3 py-2 rounded-xl border transition-colors ${
+              isLeaderRow ? 'bg-accent/5 border-accent/40' : 'bg-surface border-edge'
+            }`}
           >
-            <div className="member-avatar" style={{ position: 'relative' }}>
+            <div className="relative shrink-0">
               <AvatarWithBorder
                 displayName={m.user.displayName}
                 avatarUrl={avatarUrl}
@@ -162,60 +166,49 @@ export function MemberList({ members, partyId, isPrivate, currentUserId, onVisib
                 size="sm"
               />
               <span
-                className={`presence-dot presence-dot-${m.isOnline ? 'online' : 'offline'}`}
+                className={`absolute bottom-2 right-2 w-3 h-3 rounded-full border-2 border-surface ${
+                  m.isOnline ? 'bg-success' : 'bg-muted'
+                }`}
                 title={m.isOnline ? 'En línea' : 'Desconectado'}
               />
             </div>
 
-            <div className="member-info">
-              <p className="member-name">
+            <div className="min-w-0 flex-1 flex items-center gap-1.5">
+              <span className="font-bold text-primary text-sm tracking-wide truncate">
                 {m.user.displayName}
-                {/* Etiqueta de líder junto al nombre para que sea inmediatamente visible */}
-                {m.role === 'leader' && (
-                  <span className="member-leader-badge">👑 Líder</span>
-                )}
-              </p>
-              <p className="member-username">@{m.user.username}</p>
-              {m.user.activeCosmetics?.titleText && (
-                <p
-                  className="member-title"
-                  style={{
-                    margin: '2px 0 0',
-                    fontSize: '12px',
-                    color: 'var(--accent)',
-                    fontWeight: 600,
-                  }}
-                >
-                  {m.user.activeCosmetics.titleText}
-                </p>
+              </span>
+              {isLeaderRow && (
+                <span className="shrink-0 text-amber-400 text-sm" title="Líder">👑</span>
+              )}
+              {title && (
+                <span className="shrink-0 max-w-[88px] truncate text-[10px] font-bold uppercase tracking-wider text-accent bg-accent/10 border border-accent/30 rounded px-1.5 py-0.5">
+                  {title}
+                </span>
               )}
             </div>
 
-            <div className="member-stats">
-              <span className="member-xp">⚡{m.user.stats?.xp ?? 0}</span>
-              {/* Texto de estado de presencia */}
-              <span className={`member-presence-label member-presence-label-${m.isOnline ? 'online' : 'offline'}`}>
-                {m.isOnline ? 'En línea' : 'Desconectado'}
-              </span>
-              {isLeader && m.userId !== currentUserId && (
-                <button
-                  className="member-remove-btn"
-                  title="Remover miembro"
-                  onClick={() => onRemoveMember(m.userId)}
-                >
-                  ✕
-                </button>
-              )}
-            </div>
+            <span className="shrink-0 flex items-center gap-1 text-xs font-bold text-warning bg-warning/10 border border-warning/30 rounded-full px-2 py-0.5 tabular-nums">
+              ⚡ {m.user.stats?.xp ?? 0}
+            </span>
+
+            {isLeader && m.userId !== currentUserId && (
+              <button
+                className="shrink-0 w-6 h-6 flex items-center justify-center rounded-md text-muted hover:text-danger hover:bg-danger/10 transition-colors"
+                title="Remover miembro"
+                onClick={() => onRemoveMember(m.userId)}
+              >
+                ✕
+              </button>
+            )}
           </div>
           )
         })}
       </div>
 
       {/* ─ Acciones del miembro ─ */}
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', marginTop: '16px' }}>
+      <div className="flex flex-col gap-2 mt-4">
         <button
-          className="party-leave-btn"
+          className="w-full px-4 py-3 rounded-xl bg-surface border border-edge text-secondary font-semibold text-sm hover:border-danger hover:text-danger transition-colors"
           onClick={onLeave}
         >
           🚪 Salir de la party
@@ -223,22 +216,22 @@ export function MemberList({ members, partyId, isPrivate, currentUserId, onVisib
 
         {isLeader && (
           confirmClose ? (
-            <div className="party-close-confirm">
-              <p style={{ fontSize: '13px', color: 'var(--text-secondary)', margin: 0 }}>
+            <div className="flex flex-col gap-2 p-3 rounded-xl bg-danger/5 border border-danger/30">
+              <p className="text-[13px] text-secondary m-0">
                 ¿Cerrás la party para todos?
               </p>
-              <div style={{ display: 'flex', gap: '8px' }}>
-                <button className="party-close-confirm-btn" onClick={onCloseParty}>
+              <div className="flex gap-2">
+                <button className="flex-1 px-3 py-2 rounded-lg bg-danger text-white font-semibold text-sm" onClick={onCloseParty}>
                   Sí, cerrar
                 </button>
-                <button className="party-close-cancel-btn" onClick={() => setConfirmClose(false)}>
+                <button className="flex-1 px-3 py-2 rounded-lg bg-surface border border-edge text-secondary font-semibold text-sm hover:text-primary transition-colors" onClick={() => setConfirmClose(false)}>
                   Cancelar
                 </button>
               </div>
             </div>
           ) : (
             <button
-              className="party-close-btn"
+              className="w-full px-4 py-3 rounded-xl bg-surface border border-edge text-secondary font-semibold text-sm hover:border-danger hover:text-danger transition-colors"
               onClick={() => setConfirmClose(true)}
             >
               🔒 Cerrar party

--- a/frontend/src/components/PartyComponents.tsx
+++ b/frontend/src/components/PartyComponents.tsx
@@ -450,10 +450,13 @@ export function UploadNoteCard({ onUpload, isLoading }: UploadNoteCardProps) {
 
   if (!expanded) {
     return (
-      <button className="upload-cta" onClick={() => setExpanded(true)}>
-        <span className="upload-cta-icon">✨</span>
-        <span>Crear Quest con IA</span>
-        <span className="upload-cta-sub">Subí un apunte → quiz automático</span>
+      <button
+        className="w-full flex flex-col items-center gap-1 px-4 py-5 rounded-2xl bg-surface border border-edge hover:border-accent transition-colors"
+        onClick={() => setExpanded(true)}
+      >
+        <span className="text-3xl">✨</span>
+        <span className="font-semibold text-primary">Crear Quest con IA</span>
+        <span className="text-xs text-muted">Subí un apunte → quiz automático</span>
       </button>
     )
   }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -150,63 +150,69 @@
   --shadow-accent: 0 0 24px var(--accent-glow);
 }
 
-html {
-  transition:
-    background 0.2s ease,
-    color 0.2s ease;
-}
+/* Element defaults & reset live in @layer base so Tailwind's utilities (a later
+   layer) always win. Unlayered, these beat every utility regardless of
+   specificity — e.g. `* { padding:0 }` killed all p-*/m-*, and
+   `button { background:none }` killed bg-* on every button. */
+@layer base {
+  html {
+    transition:
+      background 0.2s ease,
+      color 0.2s ease;
+  }
 
-*,
-*::before,
-*::after {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
-  scrollbar-width: none;
-  -ms-overflow-style: none;
-}
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+  }
 
-*::-webkit-scrollbar {
-  display: none;
-}
+  *::-webkit-scrollbar {
+    display: none;
+  }
 
-body {
-  background: var(--bg-base);
-  height: 100dvh;
-  overflow: hidden;
-}
+  body {
+    background: var(--bg-base);
+    height: 100dvh;
+    overflow: hidden;
+  }
 
-#root {
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-}
+  #root {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+  }
 
-h1,
-h2,
-h3,
-h4 {
-  color: var(--text-primary);
-  font-weight: 700;
-  line-height: 1.2;
-}
-p {
-  color: var(--text-secondary);
-}
-a {
-  color: var(--accent-light);
-  text-decoration: none;
-}
-button {
-  cursor: pointer;
-  font-family: inherit;
-  border: none;
-  background: none;
-}
-input,
-textarea,
-select {
-  font-family: inherit;
+  h1,
+  h2,
+  h3,
+  h4 {
+    color: var(--text-primary);
+    font-weight: 700;
+    line-height: 1.2;
+  }
+  p {
+    color: var(--text-secondary);
+  }
+  a {
+    color: var(--accent-light);
+    text-decoration: none;
+  }
+  button {
+    cursor: pointer;
+    font-family: inherit;
+    border: none;
+    background: none;
+  }
+  input,
+  textarea,
+  select {
+    font-family: inherit;
+  }
 }
 
 /* ─── Keyframes ──────────────────────────────────────────────────────────── */


### PR DESCRIPTION
## Resolves

Closes #

## What changed

- 

## How to test

1. 

## Checklist

- [ ] Linked issue is included
- [ ] Changes were tested
- [ ] Relevant docs were updated