### PR TITLE
feat(quiz): 10s timer w/ auto-advance + fix(ai): update deprecated Gemini model

### DIFF
--- a/backend/src/common/dto/index.ts
+++ b/backend/src/common/dto/index.ts
@@ -166,7 +166,8 @@ export class SubmitAnswerDto {
   @IsUUID() questId: string;
   @IsOptional() @IsUUID() attemptId?: string;
   @IsNumber() @Min(0) questionIndex: number;
-  @IsNumber() @Min(0) @Max(3) selectedOption: number;
+  // -1 = sin respuesta (se agotó el tiempo); cuenta como incorrecta.
+  @IsNumber() @Min(-1) @Max(3) selectedOption: number;
   @IsNumber() @Min(0) timeSpentMs: number;
 }
 

--- a/backend/src/modules/ai/providers/gemini-quiz.provider.ts
+++ b/backend/src/modules/ai/providers/gemini-quiz.provider.ts
@@ -83,7 +83,7 @@ export class GeminiQuizProvider implements QuizAiProvider {
 
     const genAI = new GoogleGenerativeAI(apiKey);
     const model = genAI.getGenerativeModel({
-      model: options?.model ?? this.cfg.get('GEMINI_MODEL', 'gemini-1.5-flash'),
+      model: options?.model ?? this.cfg.get('GEMINI_MODEL', 'gemini-2.0-flash'),
     });
 
     const result = await model.generateContent(

--- a/frontend/src/components/quiz/QuizComponents.tsx
+++ b/frontend/src/components/quiz/QuizComponents.tsx
@@ -9,8 +9,8 @@ interface ScoreHeaderProps {
 }
 
 export function ScoreHeader({ scores, timeLeft, currentIndex, total }: ScoreHeaderProps) {
-  const timerPct = (timeLeft / 20) * 100
-  const timerColor = timeLeft > 10 ? '#10b981' : timeLeft > 5 ? '#f59e0b' : '#ef4444'
+  const timerPct = (timeLeft / 10) * 100
+  const timerColor = timeLeft > 6 ? '#10b981' : timeLeft > 3 ? '#f59e0b' : '#ef4444'
 
   return (
     <div className="bg-surface px-4 py-3 flex flex-col gap-2 border-b border-[var(--overlay-border)]">

--- a/frontend/src/hooks/useQuiz.ts
+++ b/frontend/src/hooks/useQuiz.ts
@@ -3,7 +3,7 @@ import { AxiosError } from 'axios'
 import { questService, type Quest, type QuizQuestion, type AnswerResult } from '../services/questService'
 import { skillTreeService } from '../services/skillTreeService'
 
-const QUESTION_TIME_MS = 20000
+const QUESTION_TIME_MS = 10000
 
 export function useQuiz(questId: string) {
   const [quest, setQuest] = useState<Quest | null>(null)
@@ -17,6 +17,8 @@ export function useQuiz(questId: string) {
   const [loadError, setLoadError] = useState<string | null>(null)
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const startTimeRef = useRef<number>(0)
+  // Guards against double-submit (e.g. a click landing the same instant the timer expires).
+  const lockRef = useRef(false)
   const currentQ: QuizQuestion | null = quest?.questions[currentIndex] ?? null
 
   useEffect(() => {
@@ -65,28 +67,12 @@ export function useQuiz(questId: string) {
     }
   }, [questId])
 
-  // Timer por pregunta
-  useEffect(() => {
-    if (!quest || isFinished || !currentQ) return
-    setTimeLeft(QUESTION_TIME_MS / 1000)
-    startTimeRef.current = Date.now()
-
-    timerRef.current = setInterval(() => {
-      const elapsed = Date.now() - startTimeRef.current
-      const remaining = Math.max(0, QUESTION_TIME_MS - elapsed)
-      setTimeLeft(Math.ceil(remaining / 1000))
-      if (remaining === 0) clearInterval(timerRef.current!)
-    }, 200)
-
-    return () => clearInterval(timerRef.current!)
-  }, [currentIndex, quest, isFinished, currentQ])
-
-  const answer = useCallback(async (optionId: string) => {
-    if (!currentQ || result || !attemptId) return
+  // Envía una selección (opción real, o -1 si se agotó el tiempo) y avanza tras una pausa.
+  const submitSelection = useCallback(async (selectedOption: number) => {
+    if (!currentQ || !attemptId || lockRef.current) return
+    lockRef.current = true
     clearInterval(timerRef.current!)
     const elapsedMs = Date.now() - startTimeRef.current
-    const selectedOption = currentQ.options.findIndex((option) => option.id === optionId)
-    if (selectedOption < 0) return
 
     const res = await questService.submitAnswer(
       questId,
@@ -122,8 +108,39 @@ export function useQuiz(questId: string) {
         setAttemptId('')
         setIsFinished(true)
       }
+      lockRef.current = false
     }, 2500)
-  }, [attemptId, currentQ, result, currentIndex, quest, questId])
+  }, [attemptId, currentQ, currentIndex, quest, questId])
+
+  // Latest submit fn for the timer interval, without re-arming the timer on every change.
+  const submitRef = useRef(submitSelection)
+  submitRef.current = submitSelection
+
+  const answer = useCallback((optionId: string) => {
+    const selectedOption = currentQ?.options.findIndex((option) => option.id === optionId) ?? -1
+    if (selectedOption < 0) return
+    void submitSelection(selectedOption)
+  }, [currentQ, submitSelection])
+
+  // Timer por pregunta — al llegar a 0 envía -1 (sin respuesta) y salta a la siguiente.
+  useEffect(() => {
+    if (!quest || isFinished || !currentQ) return
+    lockRef.current = false
+    setTimeLeft(QUESTION_TIME_MS / 1000)
+    startTimeRef.current = Date.now()
+
+    timerRef.current = setInterval(() => {
+      const elapsed = Date.now() - startTimeRef.current
+      const remaining = Math.max(0, QUESTION_TIME_MS - elapsed)
+      setTimeLeft(Math.ceil(remaining / 1000))
+      if (remaining === 0) {
+        clearInterval(timerRef.current!)
+        void submitRef.current(-1)
+      }
+    }, 200)
+
+    return () => clearInterval(timerRef.current!)
+  }, [currentIndex, quest, isFinished, currentQ])
 
   return {
     quest,


### PR DESCRIPTION
## Resolves

Baja el timer del quiz a 10s con auto-avance, y arregla la generación de quests por IA (modelo de Gemini deprecado).

## What changed

### Timer del quiz (10s + auto-avance)
- `useQuiz.ts`: `QUESTION_TIME_MS` 20s → **10s**. Antes, al llegar a 0 el timer se frenaba y **no pasaba nada** (no había handler de timeout). Ahora, al agotarse, envía la respuesta como **`-1` (sin respuesta)**, la muestra como incorrecta (revela la correcta) y **salta a la siguiente** — igual que al responder. Refactoricé la lógica de submit en una función compartida (`submitSelection`) con un `lockRef` para evitar doble-submit si un click cae justo cuando expira.
- `common/dto/index.ts`: `SubmitAnswerDto.selectedOption` ahora acepta `-1` (`@Min(-1)`) como sentinela de timeout. El scoring ya lo cuenta como incorrecto (`correctIndex` nunca es -1).
- `QuizComponents.tsx`: el anillo del timer estaba hardcodeado a 20s (`/20`, verde `>10`, ámbar `>5`) → reescalado a 10s (`/10`, verde `>6`, ámbar `>3`).

### Generación de quests por IA (PDF)
- `gemini-quiz.provider.ts`: el modelo por defecto era **`gemini-1.5-flash`**, que Google **deprecó** (retirado ~2025) → con una API key nueva da error → la generación falla. Actualizado a **`gemini-2.0-flash`** (vigente, rápido). Verifiqué que la extracción de texto del PDF (`pdf-parse` v2) funciona OK en este entorno, así que el cuello de botella era el modelo, no el PDF.

## How to test

1. `pnpm --dir backend start:dev` (con `GEMINI_API_KEY` en `backend/.env`).
2. Crear quest desde un PDF con texto → debería generar (antes fallaba por el modelo deprecado).
3. Jugar el quiz: cada pregunta dura **10s**; si no respondés, salta sola a la siguiente y cuenta incorrecta.

## Notas / hallazgos (NO de este PR)

- **El build de PRODUCCIÓN del frontend de `dev` está roto** (preexistente): `components/party/PartyComponents.tsx` tiene `TournamentCreationModalLocal` declarado pero **nunca usado** (TS6133) → `pnpm build` falla. Es dead code de un refactor previo (contiene el form de crear torneo). Hay que **wirearlo o borrarlo**. (El backend `nest build` sí pasa.)
- `quests.attempts.spec.ts` tiene errores de tipo en mocks (TS2352) que rompen `tsc --noEmit` (no el build de nest).
- **PDF escaneado / sin texto**: si el PDF no tiene texto extraíble, falla con "El PDF no tiene suficiente texto". Mejora futura: usar Gemini multimodal (mandar el PDF directo) para PDFs escaneados.

## Checklist
- [ ] Linked issue is included
- [x] Changes were tested (timer logic + backend build; modelo Gemini pendiente de confirmar con key real)
- [x] Relevant docs were updated if needed
