### PR TITLE
feat(ui): adjuntos drag&drop/paste, tema claro y layout responsive

### DIFF
--- a/frontend/src/components/PagePrimitives.tsx
+++ b/frontend/src/components/PagePrimitives.tsx
@@ -150,7 +150,7 @@ export function SegmentedTabs<T extends string>({
     <div
       role="tablist"
       aria-label={label}
-      className="inline-flex items-center gap-1 bg-surface border border-edge rounded-lg p-1"
+      className="flex w-full items-center gap-1 bg-[var(--overlay-subtle)] border border-edge rounded-lg p-1"
     >
       {tabs.map((tab) => {
         const isActive = tab.id === active
@@ -160,9 +160,9 @@ export function SegmentedTabs<T extends string>({
             role="tab"
             aria-selected={isActive}
             onClick={() => onChange(tab.id)}
-            className={`inline-flex items-center justify-center gap-1.5 min-h-11 px-4 rounded-lg text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
+            className={`flex-1 inline-flex items-center justify-center gap-1.5 min-h-11 px-2 rounded-lg text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
               isActive
-                ? 'bg-accent text-primary'
+                ? 'bg-accent text-on-accent'
                 : 'text-secondary hover:text-primary'
             }`}
           >

--- a/frontend/src/components/UI.tsx
+++ b/frontend/src/components/UI.tsx
@@ -16,7 +16,7 @@ const variantClasses: Record<string, string> = {
   primary:
     'bg-accent text-on-accent hover:bg-accent-light hover:shadow-[0_0_24px_rgba(124,58,237,0.3)] hover:-translate-y-px disabled:opacity-50 disabled:cursor-not-allowed',
   secondary:
-    'bg-elevated text-primary border border-[var(--overlay-border)] hover:border-white/[0.15] hover:bg-panel disabled:opacity-50 disabled:cursor-not-allowed',
+    'bg-elevated text-primary border border-[var(--overlay-border)] hover:border-[var(--border-hover)] hover:bg-panel disabled:opacity-50 disabled:cursor-not-allowed',
   ghost:
     'bg-transparent text-secondary hover:text-primary disabled:opacity-50 disabled:cursor-not-allowed',
   danger:

--- a/frontend/src/components/dashboard/DashboardComponents.tsx
+++ b/frontend/src/components/dashboard/DashboardComponents.tsx
@@ -50,7 +50,7 @@ export function ActivePartyBanner({ party }: { party: Party | null }) {
       <div className="flex items-center gap-3 min-w-0 flex-1">
         <span className="w-2.5 h-2.5 bg-emerald-500 rounded-full shadow-[0_0_8px_#10b981] animate-pulse" />
         <div className="min-w-0 flex-1">
-          <p className="text-[11px] text-emerald-400 font-semibold uppercase tracking-wide">Party Activa</p>
+          <p className="text-[11px] text-success font-semibold uppercase tracking-wide">Party Activa</p>
           <p className="text-[15px] font-bold text-primary truncate">{party.name ?? party.subject?.name ?? 'Party activa'}</p>
         </div>
       </div>
@@ -80,7 +80,7 @@ function SubjectCard({ subject }: { subject: Subject }) {
         <p className="font-semibold text-[15px] text-primary truncate">{subject.name}</p>
         <p className="text-xs text-muted mt-0.5">Sem. {subject.semester}</p>
         <button
-          className="text-xs text-emerald-400 font-semibold flex items-center gap-1 mt-1 cursor-pointer hover:underline"
+          className="text-xs text-success font-semibold flex items-center gap-1 mt-1 cursor-pointer hover:underline"
           onClick={(event) => {
             event.stopPropagation()
             navigate(`/subjects/${subject.id}/skill-tree`)

--- a/frontend/src/components/dashboard/HomeLeaderboardPreview.tsx
+++ b/frontend/src/components/dashboard/HomeLeaderboardPreview.tsx
@@ -53,7 +53,7 @@ export const HomeLeaderboardPreview = ({ subjects }: { subjects: Subject[] }) =>
       </div>
       
       {/* Tabs */}
-      <div className="flex gap-2 overflow-x-auto pb-1 scrollbar-none relative">
+      <div className="flex flex-wrap gap-2 pb-1 relative">
         <motion.button
           whileHover={{ scale: 1.05 }}
           whileTap={{ scale: 0.95 }}
@@ -87,7 +87,7 @@ export const HomeLeaderboardPreview = ({ subjects }: { subjects: Subject[] }) =>
       <div className="min-h-[220px]">
         {isLoading ? (
           <div className="flex justify-center items-center h-full py-10">
-            <div className="w-8 h-8 border-2 border-[var(--overlay-border)] border-t-[#7c3aed] rounded-full animate-spin" />
+            <div className="w-8 h-8 border-2 border-[var(--overlay-border)] border-t-accent rounded-full animate-spin" />
           </div>
         ) : error ? (
           <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="text-red-400 text-xs text-center py-4 bg-red-500/10 rounded-xl border border-red-500/20">
@@ -128,9 +128,9 @@ export const HomeLeaderboardPreview = ({ subjects }: { subjects: Subject[] }) =>
                     <p className="text-primary text-[13px] font-semibold truncate group-hover:text-accent-light transition-colors">{entry.displayName}</p>
                     <p className="text-muted text-[10px] truncate">@{entry.username}</p>
                   </div>
-                  <div className="text-right shrink-0 bg-black/20 px-2 py-1 rounded-md">
+                  <div className="text-right shrink-0 bg-[var(--overlay-soft)] px-2 py-1 rounded-md">
                     <span className="text-xs font-bold text-[10px] mr-1.5" title={league.name}>{league.icon}</span>
-                    <span className="text-xs font-bold drop-shadow-md" style={{ color: league.color }}>{entry.elo} ELO</span>
+                    <span className="text-xs font-bold text-primary">{entry.elo} ELO</span>
                   </div>
                 </motion.div>
               );

--- a/frontend/src/components/dashboard/HomeLeaderboardPreview.tsx
+++ b/frontend/src/components/dashboard/HomeLeaderboardPreview.tsx
@@ -60,7 +60,7 @@ export const HomeLeaderboardPreview = ({ subjects }: { subjects: Subject[] }) =>
           onClick={() => setSelectedTab('global')}
           className={`px-3 py-1.5 rounded-lg text-xs font-semibold whitespace-nowrap transition-all duration-200 cursor-pointer ${
             selectedTab === 'global' 
-              ? 'bg-accent text-primary shadow-accent/20 shadow-lg' 
+              ? 'bg-accent text-on-accent shadow-accent/20 shadow-lg'
               : 'bg-elevated text-muted border border-[var(--overlay-border)] hover:border-[var(--overlay-border)]'
           }`}
         >
@@ -74,7 +74,7 @@ export const HomeLeaderboardPreview = ({ subjects }: { subjects: Subject[] }) =>
             onClick={() => setSelectedTab(sub.id)}
             className={`px-3 py-1.5 rounded-lg text-xs font-semibold whitespace-nowrap transition-all duration-200 cursor-pointer ${
               selectedTab === sub.id 
-                ? 'bg-accent text-primary shadow-accent/20 shadow-lg' 
+                ? 'bg-accent text-on-accent shadow-accent/20 shadow-lg'
                 : 'bg-elevated text-muted border border-[var(--overlay-border)] hover:border-[var(--overlay-border)]'
             }`}
           >

--- a/frontend/src/components/party-chat/ChatBox.tsx
+++ b/frontend/src/components/party-chat/ChatBox.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import toast from 'react-hot-toast'
 import type { ChatMessage } from '../../services/partyService'
 import { ChatComposer } from './ChatComposer'
@@ -20,10 +20,22 @@ type Props = {
 
 export function ChatBox({ messages, isLoading, error, currentUserId = '', onSendText, onSendFile, onSendAudio }: Props) {
   const endRef = useRef<HTMLDivElement>(null)
+  const [isUploadingFile, setIsUploadingFile] = useState(false)
 
   useEffect(() => {
     endRef.current?.scrollIntoView({ behavior: 'smooth' })
-  }, [messages.length])
+  }, [messages.length, isUploadingFile])
+
+  // Wraps the file send with an "uploading" state so all entry points
+  // (drop, attach button, paste) show a pending indicator until it lands.
+  const handleSendFile = useCallback(async (file: File) => {
+    setIsUploadingFile(true)
+    try {
+      await onSendFile(file)
+    } finally {
+      setIsUploadingFile(false)
+    }
+  }, [onSendFile])
 
   // Drag a file anywhere over the chat to send it (WhatsApp-style).
   const { isDragging, dropZoneProps } = useFileDrop({
@@ -32,7 +44,7 @@ export function ChatBox({ messages, isLoading, error, currentUserId = '', onSend
         toast.error('Solo PDF, TXT, DOC o DOCX')
         return
       }
-      void onSendFile(file)
+      void handleSendFile(file)
     },
   })
 
@@ -72,13 +84,19 @@ export function ChatBox({ messages, isLoading, error, currentUserId = '', onSend
             />
           ))
         )}
+        {isUploadingFile && (
+          <div className="self-end flex items-center gap-2 bg-[rgba(124,58,237,0.10)] border border-[rgba(124,58,237,0.30)] rounded-2xl px-3 py-2 text-sm text-secondary">
+            <Spinner size="sm" />
+            Subiendo archivo…
+          </div>
+        )}
         <div ref={endRef} />
       </div>
 
       {/* Sticky composer — sticks above mobile nav via safe-area padding in ChatComposer */}
       <ChatComposer
         onSendText={onSendText}
-        onSendFile={onSendFile}
+        onSendFile={handleSendFile}
         onSendAudio={onSendAudio}
       />
     </div>

--- a/frontend/src/components/party-chat/ChatBox.tsx
+++ b/frontend/src/components/party-chat/ChatBox.tsx
@@ -1,9 +1,12 @@
 import { useEffect, useRef } from 'react'
+import toast from 'react-hot-toast'
 import type { ChatMessage } from '../../services/partyService'
 import { ChatComposer } from './ChatComposer'
 import { ChatMessageItem } from './ChatMessageItem'
+import { isAllowedChatFile } from './chatMessageGuards'
 import { Spinner } from '../UI'
-import { MessageCircle } from 'lucide-react'
+import { MessageCircle, Paperclip } from 'lucide-react'
+import { useFileDrop } from '../../hooks/useFileDrop'
 
 type Props = {
   messages: ChatMessage[]
@@ -22,8 +25,26 @@ export function ChatBox({ messages, isLoading, error, currentUserId = '', onSend
     endRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [messages.length])
 
+  // Drag a file anywhere over the chat to send it (WhatsApp-style).
+  const { isDragging, dropZoneProps } = useFileDrop({
+    onFile: (file) => {
+      if (!isAllowedChatFile(file)) {
+        toast.error('Solo PDF, TXT, DOC o DOCX')
+        return
+      }
+      void onSendFile(file)
+    },
+  })
+
   return (
-    <div className="flex flex-col flex-1 min-h-0">
+    <div className="relative flex flex-col flex-1 min-h-0" {...dropZoneProps}>
+      {isDragging && (
+        <div className="pointer-events-none absolute inset-0 z-30 m-2 flex flex-col items-center justify-center gap-3 rounded-2xl border-2 border-dashed border-accent bg-base/85 backdrop-blur-sm text-accent-light">
+          <Paperclip size={32} aria-hidden="true" />
+          <p className="text-sm font-semibold">Soltá el archivo para enviarlo</p>
+          <p className="text-xs text-muted">PDF, TXT, DOC o DOCX</p>
+        </div>
+      )}
       {/* Scrollable message list */}
       <div className="flex-1 overflow-y-auto px-4 py-3 flex flex-col gap-3 min-h-0">
         {isLoading ? (

--- a/frontend/src/components/party-chat/ChatComposer.tsx
+++ b/frontend/src/components/party-chat/ChatComposer.tsx
@@ -47,8 +47,9 @@ export function ChatComposer({ onSendText, onSendFile, onSendAudio }: Props) {
     if (fileInputRef.current) fileInputRef.current.value = ''
   }
 
-  // Drag-and-drop + paste — reuses handleFile (which validates and reports errors).
-  const { isDragging, dropZoneProps, onPaste } = useFileDrop({
+  // Paste a file (Ctrl/Cmd+V) into the message box. Drag-and-drop is handled
+  // one level up in ChatBox so it covers the whole chat area (WhatsApp-style).
+  const { onPaste } = useFileDrop({
     onFile: (file) => { void handleFile(file) },
     disabled: isRecording,
   })
@@ -105,16 +106,7 @@ export function ChatComposer({ onSendText, onSendFile, onSendAudio }: Props) {
   }
 
   return (
-    <div
-      {...dropZoneProps}
-      className={`relative shrink-0 z-10 border-t bg-base px-3 py-2 pb-[calc(env(safe-area-inset-bottom,0px)+8px)] transition-colors ${isDragging ? 'border-accent bg-accent-bg' : 'border-edge'}`}
-    >
-      {isDragging && (
-        <div className="pointer-events-none absolute inset-1 z-20 flex items-center justify-center gap-2 rounded-lg border-2 border-dashed border-accent bg-base/85 text-sm font-medium text-accent-light">
-          <Paperclip size={16} aria-hidden="true" />
-          Soltá el archivo para adjuntarlo
-        </div>
-      )}
+    <div className="shrink-0 z-10 border-t border-edge bg-base px-3 py-2 pb-[calc(env(safe-area-inset-bottom,0px)+8px)]">
       <form className="flex items-end gap-2" onSubmit={submitText}>
         {/* Hidden native file input — labelled via <label htmlFor> so getByLabelText resolves it */}
         <label htmlFor="chat-file-input" className="sr-only">Adjuntar archivo</label>

--- a/frontend/src/components/party-chat/ChatComposer.tsx
+++ b/frontend/src/components/party-chat/ChatComposer.tsx
@@ -174,7 +174,7 @@ export function ChatComposer({ onSendText, onSendFile, onSendAudio }: Props) {
             className={`size-11 shrink-0 flex items-center justify-center rounded-lg border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
               isRecording
                 ? 'bg-danger/10 border-danger/50 text-danger hover:bg-danger/20'
-                : 'bg-accent text-primary border-accent hover:bg-accent-light'
+                : 'bg-accent text-on-accent border-accent hover:bg-accent-light'
             }`}
           >
             {isRecording ? (

--- a/frontend/src/components/party-chat/ChatComposer.tsx
+++ b/frontend/src/components/party-chat/ChatComposer.tsx
@@ -1,6 +1,7 @@
 import { useLayoutEffect, useRef, useState } from 'react'
 import { Paperclip, Send, Mic, Square } from 'lucide-react'
 import { isAllowedChatFile } from './chatMessageGuards'
+import { useFileDrop } from '../../hooks/useFileDrop'
 
 type Props = {
   onSendText: (text: string) => void
@@ -45,6 +46,12 @@ export function ChatComposer({ onSendText, onSendFile, onSendAudio }: Props) {
     await onSendFile(file)
     if (fileInputRef.current) fileInputRef.current.value = ''
   }
+
+  // Drag-and-drop + paste — reuses handleFile (which validates and reports errors).
+  const { isDragging, dropZoneProps, onPaste } = useFileDrop({
+    onFile: (file) => { void handleFile(file) },
+    disabled: isRecording,
+  })
 
   const startRecording = async () => {
     if (!navigator.mediaDevices?.getUserMedia || typeof MediaRecorder === 'undefined') {
@@ -98,7 +105,16 @@ export function ChatComposer({ onSendText, onSendFile, onSendAudio }: Props) {
   }
 
   return (
-    <div className="shrink-0 z-10 border-t border-edge bg-base px-3 py-2 pb-[calc(env(safe-area-inset-bottom,0px)+8px)]">
+    <div
+      {...dropZoneProps}
+      className={`relative shrink-0 z-10 border-t bg-base px-3 py-2 pb-[calc(env(safe-area-inset-bottom,0px)+8px)] transition-colors ${isDragging ? 'border-accent bg-accent-bg' : 'border-edge'}`}
+    >
+      {isDragging && (
+        <div className="pointer-events-none absolute inset-1 z-20 flex items-center justify-center gap-2 rounded-lg border-2 border-dashed border-accent bg-base/85 text-sm font-medium text-accent-light">
+          <Paperclip size={16} aria-hidden="true" />
+          Soltá el archivo para adjuntarlo
+        </div>
+      )}
       <form className="flex items-end gap-2" onSubmit={submitText}>
         {/* Hidden native file input — labelled via <label htmlFor> so getByLabelText resolves it */}
         <label htmlFor="chat-file-input" className="sr-only">Adjuntar archivo</label>
@@ -135,6 +151,7 @@ export function ChatComposer({ onSendText, onSendFile, onSendAudio }: Props) {
             value={text}
             onChange={(e) => setText(e.target.value)}
             onKeyDown={handleKeyDown}
+            onPaste={onPaste}
             placeholder={isRecording ? 'Tu nota de voz se está grabando' : 'Escribí un mensaje'}
             aria-label="Escribí un mensaje"
             rows={1}

--- a/frontend/src/components/party-chat/ChatMessageItem.tsx
+++ b/frontend/src/components/party-chat/ChatMessageItem.tsx
@@ -23,7 +23,7 @@ export function ChatMessageItem({ message, isOwn }: { message: ChatMessage; isOw
       {message.type === 'file' && message.attachment && (
         <div className="flex flex-col gap-2.5 w-full">
           <div className="flex items-start gap-2.5">
-            <span className="w-9 h-9 rounded-lg inline-flex items-center justify-center bg-white/[0.08] shrink-0 text-lg" aria-hidden="true">📄</span>
+            <span className="w-9 h-9 rounded-lg inline-flex items-center justify-center bg-[var(--overlay-soft)] shrink-0 text-lg" aria-hidden="true">📄</span>
             <div className="min-w-0 flex flex-col gap-0.5">
               <a
                 href={message.attachment.url}
@@ -44,7 +44,7 @@ export function ChatMessageItem({ message, isOwn }: { message: ChatMessage; isOw
       {isAudioMessage(message) && message.attachment && (
         <div className="flex flex-col gap-2.5 w-full">
           <div className="flex items-start gap-2.5">
-            <span className="w-9 h-9 rounded-lg inline-flex items-center justify-center bg-white/[0.08] shrink-0 text-lg" aria-hidden="true">🎙️</span>
+            <span className="w-9 h-9 rounded-lg inline-flex items-center justify-center bg-[var(--overlay-soft)] shrink-0 text-lg" aria-hidden="true">🎙️</span>
             <div className="min-w-0 flex flex-col gap-0.5">
               <strong className="text-sm text-primary">Nota de voz</strong>
               <span className="text-xs text-muted">

--- a/frontend/src/components/party/UploadNoteCard.tsx
+++ b/frontend/src/components/party/UploadNoteCard.tsx
@@ -1,6 +1,10 @@
 import { useState, useRef } from 'react'
 import { Sparkles, FileText, X, Paperclip } from 'lucide-react'
 import { Button } from '../../components/UI'
+import { useFileDrop } from '../../hooks/useFileDrop'
+
+const isPdf = (file: File) =>
+  file.type === 'application/pdf' || file.name.toLowerCase().endsWith('.pdf')
 
 interface UploadNoteCardProps {
   onUpload: (title: string, file?: File, textContent?: string) => Promise<unknown>
@@ -21,6 +25,20 @@ export function UploadNoteCard({ onUpload, isLoading }: UploadNoteCardProps) {
     setFileName(null)
     if (fileRef.current) fileRef.current.value = ''
   }
+
+  const pickFile = (file: File) => {
+    setSelectedFile(file)
+    setFileName(file.name)
+    if (error) setError(null)
+  }
+
+  // Drag-and-drop + paste of a PDF anywhere on the card.
+  const { isDragging, dropZoneProps, onPaste } = useFileDrop({
+    onFile: pickFile,
+    accept: isPdf,
+    onReject: () => setError('Solo se aceptan archivos PDF.'),
+    disabled: isLoading,
+  })
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -64,7 +82,12 @@ export function UploadNoteCard({ onUpload, isLoading }: UploadNoteCardProps) {
   }
 
   return (
-    <form className="flex flex-col gap-3 bg-surface border border-edge rounded-lg p-4" onSubmit={submit}>
+    <form
+      {...dropZoneProps}
+      onPaste={onPaste}
+      className={`flex flex-col gap-3 bg-surface border rounded-lg p-4 transition-colors ${isDragging ? 'border-accent bg-accent-bg' : 'border-edge'}`}
+      onSubmit={submit}
+    >
       <h3 className="text-base font-bold text-primary">Nueva Quest</h3>
 
       <div className="flex flex-col gap-1.5">
@@ -122,13 +145,12 @@ export function UploadNoteCard({ onUpload, isLoading }: UploadNoteCardProps) {
               accept="application/pdf"
               className="sr-only"
               onChange={(e) => {
-                const file = e.target.files?.[0] ?? null
-                setSelectedFile(file)
-                setFileName(file?.name ?? null)
+                const file = e.target.files?.[0]
+                if (file) pickFile(file)
               }}
             />
             <Paperclip size={16} aria-hidden="true" />
-            Elegí un PDF
+            Elegí un PDF, arrastralo o pegalo (Ctrl+V)
           </label>
         )}
       </div>

--- a/frontend/src/components/profile/EditProfileModal.tsx
+++ b/frontend/src/components/profile/EditProfileModal.tsx
@@ -54,7 +54,7 @@ export function EditProfileModal({ user, onClose, onUpdate }: EditProfileModalPr
         exit={{ y: "100%" }}
         transition={{ type: "spring", damping: 25, stiffness: 300 }}
       >
-        <div className="w-9 h-1 rounded-sm bg-white/[0.15] mx-auto -mb-2" />
+        <div className="w-9 h-1 rounded-sm bg-[var(--overlay-border)] mx-auto -mb-2" />
         <h2 className="text-lg font-extrabold">Editar Perfil</h2>
 
         {error && <div className="px-4 py-3 rounded-lg text-sm bg-[rgba(239,68,68,0.1)] text-danger border border-[rgba(239,68,68,0.2)]">{error}</div>}

--- a/frontend/src/components/profile/ProfileHeader.tsx
+++ b/frontend/src/components/profile/ProfileHeader.tsx
@@ -36,10 +36,14 @@ export function ProfileHeader({ user, stats, league }: ProfileHeaderProps) {
           <Badge variant="primary">Nivel {stats.level}</Badge>
           <Badge variant="success">⚡ {stats.xp} XP</Badge>
           <span
-            className="inline-flex items-center justify-center gap-1 px-3.5 py-1.5 rounded-full text-[13px] font-bold text-on-accent text-shadow-[0_1px_3px_rgba(0,0,0,0.4)] tracking-[0.3px] relative z-[1]"
+            className="inline-flex items-center justify-center gap-1 px-3.5 py-1.5 rounded-full text-[13px] font-bold text-white tracking-[0.3px] relative z-[1]"
             style={{
-              background: league.gradient,
+              // Subtle dark veil over the gradient so the pill reads as a solid
+              // colored chip (not a washed pastel) and white text stays legible
+              // on the light end of the league gradients (e.g. Platino's cyan).
+              background: `linear-gradient(rgba(0,0,0,0.14), rgba(0,0,0,0.14)), ${league.gradient}`,
               boxShadow: `0 0 8px ${league.glowColor}`,
+              textShadow: '0 1px 3px rgba(0,0,0,0.65), 0 0 2px rgba(0,0,0,0.5)',
             }}
           >
             {league.icon} {league.name}

--- a/frontend/src/components/profile/ProfileHeader.tsx
+++ b/frontend/src/components/profile/ProfileHeader.tsx
@@ -1,3 +1,5 @@
+import { Link } from 'react-router-dom'
+import { Settings } from 'lucide-react'
 import { Badge } from '../../components/UI'
 import { AvatarWithBorder } from '../../components/AvatarWithBorder'
 
@@ -10,9 +12,16 @@ interface ProfileHeaderProps {
 export function ProfileHeader({ user, stats, league }: ProfileHeaderProps) {
   return (
     <div
-      className="bg-surface border border-[var(--overlay-border)] rounded-xl p-6 flex gap-4 items-center"
+      className="relative bg-surface border border-[var(--overlay-border)] rounded-xl p-6 pr-14 flex gap-4 items-center"
       style={{ borderTop: `3px solid ${league.color}` }}
     >
+      <Link
+        to="/settings"
+        aria-label="Configuración"
+        className="absolute top-3 right-3 flex items-center justify-center size-11 rounded-lg text-muted transition-colors hover:text-primary hover:bg-elevated focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+      >
+        <Settings size={18} aria-hidden="true" />
+      </Link>
       <AvatarWithBorder
         displayName={user.displayName}
         avatarUrl={user.avatarUrl}

--- a/frontend/src/components/profile/ProfileHeader.tsx
+++ b/frontend/src/components/profile/ProfileHeader.tsx
@@ -36,7 +36,7 @@ export function ProfileHeader({ user, stats, league }: ProfileHeaderProps) {
           <Badge variant="primary">Nivel {stats.level}</Badge>
           <Badge variant="success">⚡ {stats.xp} XP</Badge>
           <span
-            className="inline-flex items-center justify-center gap-1 px-3.5 py-1.5 rounded-full text-[13px] font-bold text-primary text-shadow-[0_1px_3px_rgba(0,0,0,0.4)] tracking-[0.3px] relative z-[1]"
+            className="inline-flex items-center justify-center gap-1 px-3.5 py-1.5 rounded-full text-[13px] font-bold text-on-accent text-shadow-[0_1px_3px_rgba(0,0,0,0.4)] tracking-[0.3px] relative z-[1]"
             style={{
               background: league.gradient,
               boxShadow: `0 0 8px ${league.glowColor}`,

--- a/frontend/src/components/profile/ProfileInventory.tsx
+++ b/frontend/src/components/profile/ProfileInventory.tsx
@@ -75,7 +75,7 @@ export function ProfileInventory({
             <p className="text-[13px] font-medium text-secondary mb-2">Bordes</p>
             <div className="grid grid-cols-[repeat(auto-fill,minmax(80px,1fr))] gap-4 mt-3">
               <div
-                className={`flex flex-col items-center gap-2 px-2 py-3 border-2 border-[var(--overlay-border)] rounded-lg bg-transparent cursor-pointer transition-all duration-200 hover:border-accent hover:bg-white/[0.05] ${!user.activeCosmetics?.borderCode ? 'border-accent bg-[rgba(99,102,241,0.1)] shadow-[0_0_16px_rgba(99,102,241,0.2)]' : ''}`}
+                className={`flex flex-col items-center gap-2 px-2 py-3 border-2 border-[var(--overlay-border)] rounded-lg bg-transparent cursor-pointer transition-all duration-200 hover:border-accent hover:bg-[var(--overlay-subtle)] ${!user.activeCosmetics?.borderCode ? 'border-accent bg-[rgba(99,102,241,0.1)] shadow-[0_0_16px_rgba(99,102,241,0.2)]' : ''}`}
                 onClick={() => equipBorder(null)}
                 style={{ opacity: isUpdatingCosmetics ? 0.5 : 1 }}
               >
@@ -87,7 +87,7 @@ export function ProfileInventory({
               {inventory.borders?.map((border) => (
                 <div
                   key={border.code}
-                  className={`flex flex-col items-center gap-2 px-2 py-3 border-2 border-[var(--overlay-border)] rounded-lg bg-transparent cursor-pointer transition-all duration-200 hover:border-accent hover:bg-white/[0.05] ${user.activeCosmetics?.borderCode === border.code ? 'border-accent bg-[rgba(99,102,241,0.1)] shadow-[0_0_16px_rgba(99,102,241,0.2)]' : ''}`}
+                  className={`flex flex-col items-center gap-2 px-2 py-3 border-2 border-[var(--overlay-border)] rounded-lg bg-transparent cursor-pointer transition-all duration-200 hover:border-accent hover:bg-[var(--overlay-subtle)] ${user.activeCosmetics?.borderCode === border.code ? 'border-accent bg-[rgba(99,102,241,0.1)] shadow-[0_0_16px_rgba(99,102,241,0.2)]' : ''}`}
                   onClick={() => equipBorder(border.code)}
                   style={{ opacity: isUpdatingCosmetics ? 0.5 : 1 }}
                 >

--- a/frontend/src/components/profile/ProfileStatsGrid.tsx
+++ b/frontend/src/components/profile/ProfileStatsGrid.tsx
@@ -18,10 +18,10 @@ export function ProfileStatsGrid({ elo, winRate, stats, leagueColor }: ProfileSt
       </h3>
       <div className="grid grid-cols-2 gap-3">
         <div
-          className="bg-surface border-2 rounded-lg p-4 flex flex-col items-center justify-center text-center bg-black/20"
+          className="bg-surface border-2 rounded-lg p-4 flex flex-col items-center justify-center text-center"
           style={{ borderColor: leagueColor }}
         >
-          <span className="text-2xl font-extrabold drop-shadow-md" style={{ color: leagueColor }}>
+          <span className="text-2xl font-extrabold text-primary">
             {elo}
           </span>
           <span className="text-xs text-muted mt-1">ELO</span>

--- a/frontend/src/components/quiz/QuizComponents.tsx
+++ b/frontend/src/components/quiz/QuizComponents.tsx
@@ -75,7 +75,7 @@ export function OptionsGrid({ options, onSelect, disabled, correct, selectedId }
         return (
           <button
             key={opt.id}
-            className={`flex items-center gap-2.5 px-3 py-3.5 bg-white/[0.04] border border-[var(--overlay-border)] rounded-[18px] text-left transition-all duration-150 text-primary text-sm font-medium cursor-pointer hover:enabled:bg-elevated hover:enabled:scale-[1.02] disabled:cursor-not-allowed${isCorrect ? ' !bg-[rgba(16,185,129,0.1)] !border-success' : ''}${isSelected && !isCorrect ? ' !bg-[rgba(239,68,68,0.1)] !border-danger' : ''}`}
+            className={`flex items-center gap-2.5 px-3 py-3.5 bg-[var(--overlay-subtle)] border border-[var(--overlay-border)] rounded-[18px] text-left transition-all duration-150 text-primary text-sm font-medium cursor-pointer hover:enabled:bg-elevated hover:enabled:scale-[1.02] disabled:cursor-not-allowed${isCorrect ? ' !bg-[rgba(16,185,129,0.1)] !border-success' : ''}${isSelected && !isCorrect ? ' !bg-[rgba(239,68,68,0.1)] !border-danger' : ''}`}
             style={{ '--opt-color': optionColors[i] } as React.CSSProperties}
             onClick={() => !disabled && onSelect(opt.id)}
             disabled={disabled}
@@ -125,7 +125,7 @@ export function FeedbackOverlay({
         </div>
       </div>
       
-      <div className="text-left bg-elevated rounded-xl p-3.5 border border-white/[0.04]">
+      <div className="text-left bg-elevated rounded-xl p-3.5 border border-[var(--overlay-border)]">
         <p className="text-xs font-bold text-muted uppercase tracking-[0.5px] mb-1.5">Explicación</p>
         <p className="text-xs text-secondary leading-relaxed">{explanation}</p>
       </div>

--- a/frontend/src/components/skill-tree/SkillDetailsModal.tsx
+++ b/frontend/src/components/skill-tree/SkillDetailsModal.tsx
@@ -36,11 +36,11 @@ export function SkillDetailsModal({
             style={{ width: `${selectedNode.progressPercent}%` }}
           />
         </div>
-        <p className="text-[13px] text-[#ccd0e5]">
+        <p className="text-[13px] text-secondary">
           Progreso: {selectedNode.topicXp}/{selectedNode.xpThreshold} XP · {selectedNode.progressPercent}%
         </p>
       </div>
-      {nextStepText && <p className="text-[13px] text-primary bg-white/[0.04] border border-[var(--overlay-border)] rounded-[12px] p-3">Siguiente paso: {nextStepText}</p>}
+      {nextStepText && <p className="text-[13px] text-primary bg-[var(--overlay-subtle)] border border-[var(--overlay-border)] rounded-[12px] p-3">Siguiente paso: {nextStepText}</p>}
 
       {!selectedNode.unlocked && !selectedNode.prerequisitesMet && (
         <div className="mt-1 text-[13px]">

--- a/frontend/src/components/skill-tree/SkillNodeItem.tsx
+++ b/frontend/src/components/skill-tree/SkillNodeItem.tsx
@@ -41,7 +41,7 @@ export function SkillNodeItem({
         onSelect(node.id)
       }}
     >
-      <span className={`absolute top-1.5 right-1.5 text-[9px] rounded-full px-1.5 py-0.5 border border-transparent text-secondary bg-[var(--overlay-soft)] ${node.unlocked ? 'bg-[rgba(245,197,24,0.2)] border-[rgba(245,197,24,0.4)] text-[#d97706] dark:text-[#f5c518]' : node.prerequisitesMet ? 'bg-[rgba(124,58,237,0.2)] border-[rgba(124,58,237,0.45)] text-accent-light' : 'bg-[var(--overlay-subtle)] border-[var(--overlay-border)] text-muted'}`}>
+      <span className={`absolute top-1.5 right-1.5 text-[9px] rounded-full px-1.5 py-0.5 border border-transparent text-secondary bg-[var(--overlay-soft)] ${node.unlocked ? 'bg-[rgba(245,197,24,0.2)] border-[rgba(245,197,24,0.4)] text-warning' : node.prerequisitesMet ? 'bg-[rgba(124,58,237,0.2)] border-[rgba(124,58,237,0.45)] text-accent-light' : 'bg-[var(--overlay-subtle)] border-[var(--overlay-border)] text-muted'}`}>
         {nodeStatusLabel(node)}
       </span>
       <div className="text-2xl leading-none">{nodeIcon(node.iconKey)}</div>

--- a/frontend/src/components/subject/SubjectComponents.tsx
+++ b/frontend/src/components/subject/SubjectComponents.tsx
@@ -33,11 +33,11 @@ const semesters = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
 
 export function FilterChips({ filters, onChange }: FilterChipsProps) {
   return (
-    <div className="flex gap-2 overflow-x-auto pb-1 -mx-1 px-1 scrollbar-none">
+    <div className="flex flex-wrap gap-2 pb-1">
       <button
         className={`flex-shrink-0 min-h-9 px-3.5 rounded-full text-[13px] font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
           !filters.semester
-            ? 'bg-accent text-primary'
+            ? 'bg-accent text-on-accent'
             : 'bg-elevated text-secondary hover:text-primary border border-[var(--overlay-border)]'
         }`}
         onClick={() => onChange({ ...filters, semester: null })}
@@ -49,7 +49,7 @@ export function FilterChips({ filters, onChange }: FilterChipsProps) {
           key={s}
           className={`flex-shrink-0 min-h-9 px-3.5 rounded-full text-[13px] font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
             filters.semester === s
-              ? 'bg-accent text-primary'
+              ? 'bg-accent text-on-accent'
               : 'bg-elevated text-secondary hover:text-primary border border-[var(--overlay-border)]'
           }`}
           onClick={() => onChange({ ...filters, semester: s === filters.semester ? null : s })}

--- a/frontend/src/hooks/useFileDrop.ts
+++ b/frontend/src/hooks/useFileDrop.ts
@@ -1,0 +1,100 @@
+import { useCallback, useRef, useState } from 'react'
+
+interface UseFileDropOptions {
+  /** Receives the first dropped or pasted file. */
+  onFile: (file: File) => void
+  /** Optional type guard. Return false to reject the file (onReject fires). */
+  accept?: (file: File) => boolean
+  /** Called when a file is dropped/pasted but rejected by `accept`. */
+  onReject?: (file: File) => void
+  /** When true, drag highlighting and drop/paste handling are disabled. */
+  disabled?: boolean
+}
+
+/**
+ * Adds drag-and-drop and clipboard-paste file input to any element.
+ *
+ * - Spread `dropZoneProps` onto the container you want to accept drops.
+ * - Attach `onPaste` to a focusable element inside it (paste bubbles, so a
+ *   parent works too). Paste only intercepts when the clipboard carries a
+ *   file — pasting plain text still lands normally in a textarea/input.
+ * - `isDragging` is true only while a *file* is dragged over the zone, so you
+ *   can show a highlight without reacting to text/element drags.
+ */
+export function useFileDrop({ onFile, accept, onReject, disabled }: UseFileDropOptions) {
+  const [isDragging, setIsDragging] = useState(false)
+  // Depth counter so dragleave firing on child nodes doesn't drop the highlight
+  // until the pointer actually leaves the whole zone.
+  const dragDepth = useRef(0)
+
+  const takeFile = useCallback(
+    (file: File | undefined) => {
+      if (!file || disabled) return
+      if (accept && !accept(file)) {
+        onReject?.(file)
+        return
+      }
+      onFile(file)
+    },
+    [accept, disabled, onFile, onReject],
+  )
+
+  const carriesFiles = (e: React.DragEvent) =>
+    Array.from(e.dataTransfer.types ?? []).includes('Files')
+
+  const onDragEnter = useCallback(
+    (e: React.DragEvent) => {
+      if (disabled || !carriesFiles(e)) return
+      e.preventDefault()
+      dragDepth.current += 1
+      setIsDragging(true)
+    },
+    [disabled],
+  )
+
+  const onDragOver = useCallback(
+    (e: React.DragEvent) => {
+      if (disabled || !carriesFiles(e)) return
+      e.preventDefault() // required so the drop event fires
+    },
+    [disabled],
+  )
+
+  const onDragLeave = useCallback(
+    () => {
+      if (disabled) return
+      dragDepth.current -= 1
+      if (dragDepth.current <= 0) {
+        dragDepth.current = 0
+        setIsDragging(false)
+      }
+    },
+    [disabled],
+  )
+
+  const onDrop = useCallback(
+    (e: React.DragEvent) => {
+      if (disabled) return
+      e.preventDefault()
+      dragDepth.current = 0
+      setIsDragging(false)
+      takeFile(e.dataTransfer.files?.[0])
+    },
+    [disabled, takeFile],
+  )
+
+  const onPaste = useCallback(
+    (e: React.ClipboardEvent) => {
+      if (disabled) return
+      const file = e.clipboardData?.files?.[0]
+      if (!file) return // no file on the clipboard → let the default text paste happen
+      e.preventDefault()
+      takeFile(file)
+    },
+    [disabled, takeFile],
+  )
+
+  const dropZoneProps = { onDragEnter, onDragOver, onDragLeave, onDrop }
+
+  return { isDragging, dropZoneProps, onPaste }
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -147,6 +147,9 @@
   --accent-bg: rgba(124, 58, 237, 0.08);
   --text-on-accent: #ffffff;
 
+  /* Darker green than the dark-theme #10b981 so success text/icons stay legible
+     on light backgrounds. */
+  --green: #059669;
   --green-bg: rgba(16, 185, 129, 0.12);
   --yellow-bg: rgba(245, 158, 11, 0.12);
   --red-bg: rgba(239, 68, 68, 0.12);

--- a/frontend/src/pages/LeaderboardPage.tsx
+++ b/frontend/src/pages/LeaderboardPage.tsx
@@ -61,7 +61,7 @@ export default function LeaderboardPage() {
               <button
                 key={s.id}
                 id={`lb-tab-${s.id}`}
-                className={`py-[7px] px-4 rounded-full border border-[var(--overlay-border)] bg-surface text-secondary text-[13px] font-semibold whitespace-nowrap transition-all duration-200 cursor-pointer hover:border-accent hover:text-accent-light min-h-[44px] ${selectedSubjectId === s.id ? 'bg-accent border-accent text-primary shadow-[0_0_12px_rgba(124,58,237,0.4)]' : ''}`}
+                className={`py-[7px] px-4 rounded-full border border-[var(--overlay-border)] bg-surface text-secondary text-[13px] font-semibold whitespace-nowrap transition-all duration-200 cursor-pointer hover:border-accent hover:text-accent-light min-h-[44px] ${selectedSubjectId === s.id ? 'bg-accent border-accent text-on-accent shadow-[0_0_12px_rgba(124,58,237,0.4)]' : ''}`}
                 onClick={() => setSelectedSubjectId(s.id)}
               >
                 {s.name}

--- a/frontend/src/pages/LeaderboardPage.tsx
+++ b/frontend/src/pages/LeaderboardPage.tsx
@@ -56,7 +56,7 @@ export default function LeaderboardPage() {
       ) : (
         <>
           {/* Subject tabs: scroll on mobile, wrap on desktop */}
-          <div className="flex gap-2 overflow-x-auto px-4 pb-3 scrollbar-none">
+          <div className="flex flex-wrap gap-2 px-4 pb-3">
             {subjects.map(s => (
               <button
                 key={s.id}
@@ -211,7 +211,7 @@ function LeaderboardRow({
       </div>
       <div className="flex flex-col items-end gap-0.5 shrink-0">
         <span className="text-lg" title={league.name}>{league.icon}</span>
-        <span className="text-sm font-extrabold" style={{ color: league.color }}>{entry.elo}</span>
+        <span className="text-sm font-extrabold text-primary">{entry.elo}</span>
       </div>
     </motion.div>
   )

--- a/frontend/src/pages/PartyRoomPage.tsx
+++ b/frontend/src/pages/PartyRoomPage.tsx
@@ -104,7 +104,7 @@ const PartyRoomPage = () => {
             </Button>
           </div>
           <PartyHeader party={party} />
-          <div className="px-4 pb-3 overflow-x-auto">
+          <div className="px-4 pb-3">
             <SegmentedTabs
               tabs={TABS}
               active={activeTab}

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -104,7 +104,7 @@ export default function ProfilePage() {
   return (
     <MobileLayout>
       <PageContainer>
-        <div className="pb-10 flex flex-col gap-4">
+        <div className="pb-4 flex flex-col gap-4">
           {/* ─── Settings link ─────────────────────────────────────────── */}
           <div className="flex justify-end">
             <Link
@@ -196,43 +196,9 @@ export default function ProfilePage() {
               )}
             </div>
           </section>
-
-          {/* Account */}
-          <section className="mb-4">
-            <h3 className="text-base font-bold text-secondary uppercase tracking-[1px] pb-2">
-              Cuenta
-            </h3>
-            <div className="bg-surface border border-[var(--overlay-border)] rounded-xl p-4 flex flex-col gap-3.5">
-              <Button
-                variant="secondary"
-                onClick={() => setIsEditing(true)}
-                className="w-full"
-                size="lg"
-              >
-                <Pencil size={14} aria-hidden="true" className="mr-1" /> Editar Perfil
-              </Button>
-
-              <div className="flex items-center justify-between gap-4 px-4 py-3.5 rounded-lg border border-danger/20 bg-danger/5">
-                <div className="flex flex-col gap-1 min-w-0">
-                  <span className="text-sm font-bold text-danger">Cerrar sesión</span>
-                  <span className="text-[13px] leading-[1.4] text-secondary">
-                    Salí de tu cuenta en este dispositivo cuando quieras.
-                  </span>
-                </div>
-                <Button
-                  variant="danger"
-                  onClick={logout}
-                  className="shrink-0 min-w-24"
-                  size="md"
-                >
-                  <LogOut size={14} aria-hidden="true" className="mr-1" /> Salir
-                </Button>
-              </div>
-            </div>
-          </section>
         </div>
 
-        {/* Right column (lg+): League Ladder */}
+        {/* League Ladder */}
         <aside>
           <h3 className="text-base font-bold text-secondary uppercase tracking-[1px] pb-2 mt-6 lg:mt-0">
             Ligas
@@ -271,9 +237,41 @@ export default function ProfilePage() {
             ))}
           </div>
         </aside>
-      </div>
 
-      <div aria-hidden="true" style={{ height: "20px", flexShrink: 0 }} />
+        {/* Account — placed after Ligas so it sits at the bottom of the profile */}
+        <section className="mb-4">
+          <h3 className="text-base font-bold text-secondary uppercase tracking-[1px] pb-2">
+            Cuenta
+          </h3>
+          <div className="bg-surface border border-[var(--overlay-border)] rounded-xl p-4 flex flex-col gap-3.5">
+            <Button
+              variant="secondary"
+              onClick={() => setIsEditing(true)}
+              className="w-full"
+              size="lg"
+            >
+              <Pencil size={14} aria-hidden="true" className="mr-1" /> Editar Perfil
+            </Button>
+
+            <div className="flex items-center justify-between gap-4 px-4 py-3.5 rounded-lg border border-danger/20 bg-danger/5">
+              <div className="flex flex-col gap-1 min-w-0">
+                <span className="text-sm font-bold text-danger">Cerrar sesión</span>
+                <span className="text-[13px] leading-[1.4] text-secondary">
+                  Salí de tu cuenta en este dispositivo cuando quieras.
+                </span>
+              </div>
+              <Button
+                variant="danger"
+                onClick={logout}
+                className="shrink-0 min-w-24"
+                size="md"
+              >
+                <LogOut size={14} aria-hidden="true" className="mr-1" /> Salir
+              </Button>
+            </div>
+          </div>
+        </section>
+      </div>
 
       <AnimatePresence>
         {isEditing && (

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,7 +1,5 @@
 import { useState, useEffect } from "react"
-import { Link } from "react-router-dom"
 import {
-  Settings,
   Pencil,
   BookOpen,
   GraduationCap,
@@ -105,19 +103,7 @@ export default function ProfilePage() {
     <MobileLayout>
       <PageContainer>
         <div className="pb-4 flex flex-col gap-4">
-          {/* ─── Settings link ─────────────────────────────────────────── */}
-          <div className="flex justify-end">
-            <Link
-              to="/settings"
-              aria-label="Configuración"
-              className="flex items-center gap-1 px-3 py-1.5 rounded-full bg-surface text-muted text-sm border border-edge min-h-[44px]"
-            >
-              <Settings size={14} aria-hidden="true" />
-              Configuración
-            </Link>
-          </div>
-
-          {/* ─── User Card — full width ─────────────────────────────────── */}
+          {/* ─── User Card — full width (gear links to Settings) ────────── */}
           <div>
             <ProfileHeader user={user} stats={stats} league={league} />
           </div>

--- a/frontend/src/pages/SettingsPage.test.tsx
+++ b/frontend/src/pages/SettingsPage.test.tsx
@@ -59,18 +59,19 @@ describe('SettingsPage', () => {
     }
   })
 
-  it('shows the password form on the Seguridad tab', () => {
+  it('shows the password form on the Seguridad tab', async () => {
     renderPage()
     fireEvent.click(screen.getByRole('tab', { name: 'Seguridad' }))
-    expect(screen.getByLabelText('Contraseña actual')).toBeInTheDocument()
+    // Tab content mounts asynchronously (AnimatePresence mode="wait").
+    expect(await screen.findByLabelText('Contraseña actual')).toBeInTheDocument()
     expect(screen.getByLabelText('Nueva contraseña')).toBeInTheDocument()
     expect(screen.getByLabelText('Confirmar nueva contraseña')).toBeInTheDocument()
   })
 
-  it('disables submit when passwords do not match', () => {
+  it('disables submit when passwords do not match', async () => {
     renderPage()
     fireEvent.click(screen.getByRole('tab', { name: 'Seguridad' }))
-    fireEvent.change(screen.getByLabelText('Contraseña actual'), {
+    fireEvent.change(await screen.findByLabelText('Contraseña actual'), {
       target: { value: 'oldpassword' },
     })
     fireEvent.change(screen.getByLabelText('Nueva contraseña'), {
@@ -88,15 +89,15 @@ describe('SettingsPage', () => {
   it('keeps profile text on semantic theme colors', async () => {
     renderSettings()
     await userEvent.click(screen.getByRole('tab', { name: 'Apariencia' }))
-    await userEvent.click(screen.getByRole('switch', { name: 'Cambiar tema' }))
+    await userEvent.click(await screen.findByRole('switch', { name: 'Cambiar tema' }))
     expect(document.documentElement).toHaveAttribute('data-theme', 'light')
     expect(screen.getByText('Tema claro')).toHaveClass('text-primary')
   })
 
-  it('toggles the theme and persists it', () => {
+  it('toggles the theme and persists it', async () => {
     renderPage()
     fireEvent.click(screen.getByRole('tab', { name: 'Apariencia' }))
-    const toggle = screen.getByRole('switch', { name: 'Cambiar tema' })
+    const toggle = await screen.findByRole('switch', { name: 'Cambiar tema' })
     fireEvent.click(toggle)
     expect(document.documentElement.getAttribute('data-theme')).toBe('light')
     expect(localStorage.getItem('studyquest-theme')).toBe('light')

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -39,10 +39,11 @@ export default function SettingsPage() {
         Desktop (md+): vertical rail beside the content panel (via parent flex-row)
       */}
       <div className="flex flex-col flex-1 min-h-0 gap-4 mt-2">
-        {/* Tab rail — horizontal on mobile, vertical on desktop */}
+        {/* Tab grid — 2×2 so all tabs fit the phone column at every width
+            (no horizontal scroll / clipped labels on narrow screens). */}
         <div
           role="tablist"
-          className="flex flex-row gap-2 overflow-x-auto pb-2 scrollbar-none"
+          className="grid grid-cols-2 gap-2"
         >
           {TABS.map((tab) => (
             <button
@@ -50,10 +51,10 @@ export default function SettingsPage() {
               role="tab"
               aria-selected={activeTab === tab.id}
               onClick={() => setActiveTab(tab.id)}
-              className={`px-4 py-2 rounded-full text-sm whitespace-nowrap transition-colors min-h-[44px] md:rounded-lg md:text-left md:whitespace-normal md:w-full ${
+              className={`px-3 py-2 rounded-lg text-sm text-center transition-colors min-h-[44px] ${
                 activeTab === tab.id
                   ? 'bg-accent text-primary font-semibold'
-                  : 'bg-surface text-muted md:bg-transparent md:hover:bg-elevated md:hover:text-primary'
+                  : 'bg-surface text-muted hover:bg-elevated hover:text-primary'
               }`}
             >
               {tab.label}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -53,7 +53,7 @@ export default function SettingsPage() {
               onClick={() => setActiveTab(tab.id)}
               className={`px-3 py-2 rounded-lg text-sm text-center transition-colors min-h-[44px] ${
                 activeTab === tab.id
-                  ? 'bg-accent text-primary font-semibold'
+                  ? 'bg-accent text-on-accent font-semibold'
                   : 'bg-surface text-muted hover:bg-elevated hover:text-primary'
               }`}
             >

--- a/frontend/src/pages/SkillTreePage.tsx
+++ b/frontend/src/pages/SkillTreePage.tsx
@@ -18,6 +18,7 @@ import {
 } from '../components/skill-tree/utils'
 import { SkillDetailsModal } from '../components/skill-tree/SkillDetailsModal'
 import { SkillNodeItem } from '../components/skill-tree/SkillNodeItem'
+import { EmptyState } from '../components/PagePrimitives'
 
 const SkillTreePage = () => {
   const navigate = useNavigate()
@@ -347,6 +348,14 @@ const SkillTreePage = () => {
         </article>
       </section>
 
+      {nodes.length === 0 ? (
+        <EmptyState
+          icon="🌱"
+          title="Este árbol todavía no tiene habilidades"
+          description="Cuando esta materia tenga nodos vas a poder desbloquearlos completando quests."
+        />
+      ) : (
+        <>
       <div className="flex flex-wrap gap-2 mb-2.5">
         <span className="inline-flex items-center gap-1.5 text-xs text-secondary">
           <span className="w-[9px] h-[9px] rounded-full bg-[#f5c518]" /> Desbloqueado
@@ -424,6 +433,8 @@ const SkillTreePage = () => {
           </div>
         </div>
       </div>
+        </>
+      )}
 
       <SkillDetailsModal
         selectedNode={selectedNode}

--- a/frontend/src/pages/SkillTreePage.tsx
+++ b/frontend/src/pages/SkillTreePage.tsx
@@ -376,7 +376,7 @@ const SkillTreePage = () => {
 
       <div
         ref={canvasRef}
-        className="relative mb-[18px] bg-[radial-gradient(circle_at_top,rgba(124,58,237,0.12),transparent_55%)] border border-white/[0.06] rounded-[24px] min-h-[58vh] overflow-hidden cursor-grab touch-none active:cursor-grabbing"
+        className="relative mb-[18px] bg-[radial-gradient(circle_at_top,rgba(124,58,237,0.12),transparent_55%)] border border-[var(--overlay-border)] rounded-[24px] min-h-[58vh] overflow-hidden cursor-grab touch-none active:cursor-grabbing"
         aria-label="Mapa interactivo del árbol de habilidades"
         onPointerDown={onCanvasPointerDown}
         onPointerMove={onCanvasPointerMove}

--- a/frontend/src/pages/SkillTreePage.tsx
+++ b/frontend/src/pages/SkillTreePage.tsx
@@ -358,13 +358,13 @@ const SkillTreePage = () => {
         <>
       <div className="flex flex-wrap gap-2 mb-2.5">
         <span className="inline-flex items-center gap-1.5 text-xs text-secondary">
-          <span className="w-[9px] h-[9px] rounded-full bg-[#f5c518]" /> Desbloqueado
+          <span className="w-[9px] h-[9px] rounded-full bg-warning" /> Desbloqueado
         </span>
         <span className="inline-flex items-center gap-1.5 text-xs text-secondary">
           <span className="w-[9px] h-[9px] rounded-full bg-accent-light" /> Disponible
         </span>
         <span className="inline-flex items-center gap-1.5 text-xs text-secondary">
-          <span className="w-[9px] h-[9px] rounded-full bg-[#6f7287]" /> Bloqueado
+          <span className="w-[9px] h-[9px] rounded-full bg-muted" /> Bloqueado
         </span>
       </div>
 

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -423,7 +423,7 @@ const DashboardPage = () => {
               {isTournamentsLoading ? (
                 <div style={{ display: 'flex', justifyContent: 'center', padding: '16px' }}><Spinner /></div>
               ) : tournaments.length === 0 ? (
-                <div className="text-center py-4 px-4 bg-surface rounded-2xl border border-white/[0.05]">
+                <div className="text-center py-4 px-4 bg-surface rounded-2xl border border-[var(--overlay-border)]">
                   <p className="text-sm text-muted" style={{ margin: 0 }}>No hay torneos activos en este momento.</p>
                 </div>
               ) : (


### PR DESCRIPTION
## Resolves

N/A — mejoras de UX/UI y accesibilidad de tema claro (sin issue asociado).

## What changed

Tanda de mejoras visuales/UX centradas en **adjuntos, tema claro y layout responsive** dentro del marco de teléfono (columna `max-w-[480px]`). 14 commits atómicos.

### Adjuntos (nueva funcionalidad)
- **Nuevo hook reutilizable [`useFileDrop`](frontend/src/hooks/useFileDrop.ts)**: drag & drop + paste (Ctrl/Cmd+V). Contador de profundidad para que `dragleave` sobre hijos no rompa el estado; el paste solo intercepta cuando el clipboard trae un archivo (pegar texto sigue funcionando normal).
- **Chat (WhatsApp-style)**: arrastrar un archivo a **cualquier parte del chat** lo envía, con overlay a pantalla completa. Paste en el input. **Indicador "Subiendo archivo…"** mientras la subida está en curso (cubre drop, botón y paste — antes había ~2s sin feedback).
- **Creación de quest (PDF)**: drop/paste de PDF en toda la card, no solo el selector.

### Tema claro (bugs de legibilidad)
El tema claro existía pero varios colores estaban hardcodeados y no se adaptaban:
- Reemplazo de hex/`white-black opacity` por tokens del tema (`--overlay-subtle/soft/border`, `--border-hover`, `text-primary`, `text-on-accent`, `text-success`) en leaderboard, quiz, chat, skill-tree, dashboard y perfil.
- **Contraste de pills activas**: `text-primary` sobre `bg-accent` era texto oscuro sobre violeta en claro → ahora `text-on-accent` (blanco en ambos temas).
- **`--green` más oscuro en claro** (emerald-600) para que el texto de éxito se lea (el "Party Activa" aguamarina lavado).
- **ELO y badge de liga** en el perfil: número legible + badge con velo y contorno sobre su gradiente pálido.
- Eliminado el único `dark:` del código (no aplicaba: la app tematiza por `data-theme`, no por `prefers-color-scheme`).

### Layout / responsive
- **Tabs sin scroll horizontal**: Configuración (grid 2×2), materias (wrap), leaderboard (wrap), party tabs (`SegmentedTabs` full-width).
- **Perfil**: sección Cuenta movida debajo de Ligas, acceso a Configuración pasado a un engranaje en la card del header, y recorte del espacio muerto inferior.
- **Skill-tree**: empty state cuando la materia no tiene nodos (antes: canvas lila vacío).

### Tests
- Arreglados **4 tests de SettingsPage** que fallaban desde el reestructure #183: el contenido de tabs monta async (`AnimatePresence mode="wait"`), así que se pasaron las queries a `findBy*`. Los componentes no se tocaron.

## How to test

Reiniciá Vite (el CSS de `@layer`/tokens no siempre recarga con HMR) y probá **en tema claro y oscuro** (toggle en Configuración → Apariencia):

1. **Chat**: arrastrá un PDF/TXT/DOC a cualquier parte del chat → overlay + envío; probá también el botón 📎 y Ctrl/Cmd+V. Verificá el indicador "Subiendo archivo…" y que el mensaje llegue una sola vez (WS + dedup).
2. **Quest con IA**: arrastrá/pegá un PDF en la card de creación.
3. **Tema claro**: revisá leaderboard (pill de ELO), quiz (opciones), chat (chips de archivo/audio), perfil (ELO, badge "Platino", "Party Activa"), skill-tree.
4. **Tabs**: Configuración, Explorar Materias, Leaderboard y las de la party — sin scroll lateral en pantallas angostas (~360px).
5. **Perfil**: Cuenta abajo de Ligas, engranaje en la card, sin vacío al final.
6. **Skill-tree**: materia sin nodos → empty state.

## Checklist

- [x] `pnpm build` verde (exit 0)
- [x] `pnpm test` — 46/46 (incluye los 4 de SettingsPage que estaban rojos)
- [x] Verificado visualmente en tema claro y oscuro
- [x] Sin cambios de backend ni de WebSocket (solo UI)
- [x] Commits atómicos y convencionales
