### PR TITLE
fix(quests): resolver el link Ver PDF contra el origin del backend

### DIFF
--- a/frontend/src/components/party/PartyComponents.tsx
+++ b/frontend/src/components/party/PartyComponents.tsx
@@ -574,7 +574,7 @@ export function QuestCard({ quest, onDelete }: { quest: Quest; onDelete?: (quest
           {quest.sourcePdfUrl && (
             <a
               className="self-start mt-1 inline-flex items-center gap-1 px-2 py-1 rounded-lg bg-secondary/10 text-secondary border border-secondary/30 text-xs font-bold hover:bg-secondary/20 hover:text-primary transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-              href={new URL(quest.sourcePdfUrl, 'http://localhost:3000').toString()}
+              href={resolveAssetUrl(quest.sourcePdfUrl) ?? undefined}
               target="_blank"
               rel="noreferrer"
               onClick={(event) => event.stopPropagation()}


### PR DESCRIPTION
## Resolves
N/A — bug de prod (link Ver PDF de las quests).

## What changed
El botón **Ver PDF** de las quests hardcodeaba `http://localhost:3000` como base para resolver el `sourcePdfUrl` relativo, así que en prod daba `ERR_CONNECTION_REFUSED` (mientras los adjuntos del chat sí andaban, porque usaban el helper env-aware). Ahora usa `resolveAssetUrl` (respeta `VITE_API_URL`) como el resto de las URLs de adjuntos.

Una línea en `PartyComponents.tsx`:
- Antes: `new URL(quest.sourcePdfUrl, 'http://localhost:3000')`
- Ahora: `resolveAssetUrl(quest.sourcePdfUrl)`

## How to test
Con `VITE_API_URL` seteada al backend, entrar a una party → Quests → **Ver PDF** → abre en `<backend>/uploads/...` en vez de localhost.

## Checklist
- [x] `pnpm build` verde
- [x] `QuestCard.test.tsx` 2/2 (con env default sigue dando localhost, con VITE_API_URL da el backend)
- [x] Solo frontend, una línea