### PR TITLE
fix(users): 500 en quests-today/recommended-quests (ORDER BY playCount)

### DIFF
--- a/backend/src/modules/users/users.service.ts
+++ b/backend/src/modules/users/users.service.ts
@@ -775,7 +775,9 @@ export class UsersService {
       .andWhere('subject.isActive = true', queryParams)
       .groupBy('q.id')
       .addGroupBy('subject.id')
-      .orderBy('playCount', 'DESC')
+      // Quote the alias: Postgres folds an unquoted `playCount` to `playcount`,
+      // which doesn't match the quoted "playCount" select alias (42703).
+      .orderBy('"playCount"', 'DESC')
       .addOrderBy('q.createdAt', 'DESC')
       .offset(offset)
       .limit(limit);


### PR DESCRIPTION
## Resolves
N/A — bug de prod (500 en la home).

## What changed
El endpoint `GET /users/me/quests-today` (y `/recommended-quests`) tiraba **500** con:
```
QueryFailedError: column "playcount" does not exist  (Postgres 42703)
... ORDER BY playCount DESC ...
```
Postgres pasa los identificadores **sin comillas a minúsculas** (`playCount` → `playcount`), pero el alias del SELECT es `"playCount"` (con comillas, case-sensitive). No matcheaban → excepción.

**Fix (una línea, [users.service.ts](backend/src/modules/users/users.service.ts)):**
- Antes: `.orderBy('playCount', 'DESC')`
- Ahora: `.orderBy('"playCount"', 'DESC')`

## Por qué recién aparece
La query buggeada solo corre si el usuario tiene **materias inscriptas Y quests disponibles** (si no, hay early-return antes). Un usuario con datos reales (ej. logueado como bob) la dispara.

## How to test
Loguearse con un usuario con materias + quests → la home carga "Quests para hoy" y "Recomendados" sin 500.

## Checklist
- [x] `pnpm build` (nest build) verde
- [x] Una línea, sin cambios de comportamiento salvo el fix
- [ ] ⚠️ jest del repo roto (bug de versión preexistente) — no corre la suite, ajeno a este cambio