### PR TITLE
fix(deploy): incluir los SVG de bordes en la imagen de prod del backend

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -18,5 +18,8 @@ WORKDIR /app
 COPY --from=build /app/dist ./dist
 COPY --from=build /app/node_modules ./node_modules
 COPY package*.json ./
+# Static cosmetic assets (border SVGs) served from /uploads/borders. Without this
+# they're absent in the prod image and every border 404s.
+COPY --from=build /app/uploads/borders ./uploads/borders
 EXPOSE 3000
 CMD ["node", "dist/main"]


### PR DESCRIPTION
## Resolves
N/A — bug de prod (bordes de perfil rotos).

## What changed
Los bordes de perfil (y el marco del avatar) mostraban imagen rota en prod. Causa: se sirven desde `/uploads/borders/*.svg` ([users.service.ts](backend/src/modules/users/users.service.ts#L369)), los archivos están committeados en `backend/uploads/borders/`, **pero el stage de producción del Dockerfile solo copiaba `dist` + `node_modules`** → en prod `/app/uploads/borders/` no existía → 404 en cada SVG.

Fix: copiar `uploads/borders` a la imagen de producción.

## How to test
Deploy del backend → Perfil → Inventario → Bordes: los SVG cargan (no más ícono roto). El borde equipado se ve en el avatar.

## ⚠️ Interacción con el Volume de uploads
Si más adelante montás un Railway Volume en `/app/uploads` para persistir uploads de usuarios, ese mount **tapa** `/app/uploads/borders` (assets estáticos horneados) y los bordes volverían a romperse. Cuando llegue ese momento conviene separar: assets estáticos fuera del path del volume (ej. servir bordes desde `/app/assets`), o montar el volume en un subpath solo para archivos de usuario. Lo puedo hacer en un PR aparte.

## Checklist
- [x] SVGs confirmados en git (`backend/uploads/borders/*.svg`, 10 archivos)
- [x] Cambio de Dockerfile (build context los tiene)
- [ ] Requiere rebuild del backend en Railway (no "redeploy" del build viejo)