### PR TITLE
feat(elo): ELO progression ladder from quest performance

### DIFF
--- a/backend/src/common/leagues.spec.ts
+++ b/backend/src/common/leagues.spec.ts
@@ -1,0 +1,76 @@
+import {
+  calculateSoloEloDelta,
+  questRatingFromDifficulties,
+  DIFFICULTY_RATINGS,
+  ELO_K_FACTOR,
+  expectedScore,
+} from './leagues';
+
+describe('questRatingFromDifficulties', () => {
+  it('returns medium rating for an empty array', () => {
+    expect(questRatingFromDifficulties([])).toBe(DIFFICULTY_RATINGS.medium);
+  });
+
+  it('returns the single difficulty rating when there is one question', () => {
+    expect(questRatingFromDifficulties(['easy'])).toBe(DIFFICULTY_RATINGS.easy);
+    expect(questRatingFromDifficulties(['hard'])).toBe(DIFFICULTY_RATINGS.hard);
+  });
+
+  it('averages mixed difficulties', () => {
+    // easy(400) + hard(2000) = 2400 / 2 = 1200
+    expect(questRatingFromDifficulties(['easy', 'hard'])).toBe(1200);
+    // easy(400) + medium(1200) + hard(2000) = 3600 / 3 = 1200
+    expect(questRatingFromDifficulties(['easy', 'medium', 'hard'])).toBe(1200);
+  });
+
+  it('rounds the average', () => {
+    // easy(400) + easy(400) + hard(2000) = 2800 / 3 ≈ 933.33 → 933
+    expect(questRatingFromDifficulties(['easy', 'easy', 'hard'])).toBe(933);
+  });
+});
+
+describe('calculateSoloEloDelta', () => {
+  it('returns a positive delta when accuracy exceeds the expected score', () => {
+    // Player at elo 0 vs a medium quest (1200): expected ≈ 0.048
+    // With accuracy = 1.0, delta should be large positive
+    const delta = calculateSoloEloDelta(0, 1.0, DIFFICULTY_RATINGS.medium);
+    expect(delta).toBeGreaterThan(0);
+  });
+
+  it('returns a negative delta when accuracy is below the expected score', () => {
+    // Player at elo 2400 vs an easy quest (400): expected ≈ 0.976
+    // With accuracy = 0.0, delta should be large negative
+    const delta = calculateSoloEloDelta(2400, 0.0, DIFFICULTY_RATINGS.easy);
+    expect(delta).toBeLessThan(0);
+  });
+
+  it('returns ~0 delta when accuracy matches the expected score', () => {
+    // When accuracy === expected, delta should be 0 (or round to 0)
+    const questRating = DIFFICULTY_RATINGS.medium;
+    const currentElo = questRating; // symmetric: expected = 0.5
+    const delta = calculateSoloEloDelta(currentElo, 0.5, questRating);
+    expect(delta).toBe(0);
+  });
+
+  it('is symmetric: equal elo with accuracy 1 mirrors accuracy 0', () => {
+    const questRating = 800;
+    const elo = 800; // expected = 0.5
+    const deltaHigh = calculateSoloEloDelta(elo, 1.0, questRating);
+    const deltaLow = calculateSoloEloDelta(elo, 0.0, questRating);
+    // k * (1 - 0.5) = +16, k * (0 - 0.5) = -16
+    expect(deltaHigh).toBe(Math.round(ELO_K_FACTOR * 0.5));
+    expect(deltaLow).toBe(-Math.round(ELO_K_FACTOR * 0.5));
+    expect(deltaHigh + deltaLow).toBe(0);
+  });
+
+  it('uses the expectedScore formula internally', () => {
+    const currentElo = 1000;
+    const questRating = 1400;
+    const accuracy = 0.6;
+    const expected = expectedScore(currentElo, questRating);
+    const expectedDelta = Math.round(ELO_K_FACTOR * (accuracy - expected));
+    expect(calculateSoloEloDelta(currentElo, accuracy, questRating)).toBe(
+      expectedDelta,
+    );
+  });
+});

--- a/backend/src/common/leagues.ts
+++ b/backend/src/common/leagues.ts
@@ -1,3 +1,5 @@
+import { Difficulty } from '../modules/quests/quiz-question.entity';
+
 export interface League {
   tier: number;
   name: string;
@@ -17,8 +19,29 @@ export const LEAGUES: League[] = [
   { tier: 7, name: 'QuestMaster', minElo: 2400, maxElo: Infinity, icon: '👑',  color: '#f59e0b' },
 ];
 
-export const DEFAULT_ELO = 1200;
+export const DEFAULT_ELO = 0;
 export const ELO_K_FACTOR = 32;
+
+export const DIFFICULTY_RATINGS: Record<Difficulty, number> = {
+  easy: 400,
+  medium: 1200,
+  hard: 2000,
+};
+
+export function questRatingFromDifficulties(difficulties: Difficulty[]): number {
+  if (!difficulties.length) return DIFFICULTY_RATINGS.medium;
+  const sum = difficulties.reduce((a, d) => a + DIFFICULTY_RATINGS[d], 0);
+  return Math.round(sum / difficulties.length);
+}
+
+export function calculateSoloEloDelta(
+  currentElo: number,
+  accuracy: number,
+  questRating: number,
+): number {
+  const expected = expectedScore(currentElo, questRating);
+  return Math.round(ELO_K_FACTOR * (accuracy - expected));
+}
 
 export function getLeague(elo: number): League {
   for (let i = LEAGUES.length - 1; i >= 0; i--) {

--- a/backend/src/database/migrations/1752624000000-ResetUsersEloToZero.ts
+++ b/backend/src/database/migrations/1752624000000-ResetUsersEloToZero.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Reset every existing user's ELO to 0 so all users start the progression
+ * ladder from Hierro (DEFAULT_ELO changed from 1200 → 0).
+ *
+ * down: no-op — restoring arbitrary ELO values is not meaningful; the
+ * migration is effectively irreversible in production. If you need to roll
+ * back the DEFAULT_ELO change itself, revert the leagues.ts constant; this
+ * migration's down is intentionally a no-op.
+ */
+export class ResetUsersEloToZero1752624000000 implements MigrationInterface {
+  name = 'ResetUsersEloToZero1752624000000';
+
+  async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `UPDATE users SET stats = jsonb_set(stats, '{elo}', '0'::jsonb)`,
+    );
+  }
+
+  async down(_queryRunner: QueryRunner): Promise<void> {
+    // Intentional no-op: ELO values before this migration are not recoverable.
+    // To revert the DEFAULT_ELO constant change, update leagues.ts manually.
+  }
+}

--- a/backend/src/database/seeds/seed.ts
+++ b/backend/src/database/seeds/seed.ts
@@ -44,6 +44,7 @@ import { UserAchievement } from '../../modules/achievements/user-achievement.ent
 import { UserTitle } from '../../modules/cosmetics/user-title.entity';
 import { UserInventory } from '../../modules/cosmetics/user-inventory.entity';
 import { ProfileBorder } from '../../modules/cosmetics/profile-border.entity';
+import { DEFAULT_ELO } from '../../common/leagues';
 
 // ─── Conexión ──────────────────────────────────────────────────────────────────
 const AppDataSource = new DataSource({
@@ -757,7 +758,7 @@ async function seed() {
       stats: {
         xp: 0,
         level: 0,
-        elo: 1200,
+        elo: DEFAULT_ELO,
         quizzesPlayed: 0,
         quizzesWon: 0,
         currentStreak: 0,
@@ -1026,7 +1027,7 @@ async function seed() {
   const allUsers = await userRepo.find();
 
   for (const u of allUsers) {
-    const elo: number = (u.stats as any)?.elo ?? 1200;
+    const elo: number = (u.stats as any)?.elo ?? DEFAULT_ELO;
 
     // grant all tiers the user has reached (cumulative)
     const earnedTiers = LEAGUE_TIERS.filter((lt) => elo >= lt.minElo);

--- a/backend/src/modules/quests/quests.service.ts
+++ b/backend/src/modules/quests/quests.service.ts
@@ -20,6 +20,10 @@ import { PartiesService } from '../parties/parties.service';
 import { UsersService } from '../users/users.service';
 import { SkillTreeService } from '../skill-tree/skill-tree.service';
 import { CreateQuestDto, SubmitAnswerDto } from '../../common/dto';
+import {
+  calculateSoloEloDelta,
+  questRatingFromDifficulties,
+} from '../../common/leagues';
 
 const XP_CORRECT_BASE = 100;
 const XP_SPEED_BONUS = 50;
@@ -447,9 +451,19 @@ export class QuestsService {
       score: activeAttempt.score,
     });
 
+    let eloDelta = 0;
+    let eloAfter = 0;
     if (activeAttempt.attemptNumber === 1) {
       await this.usersService.addXp(userId, totalXp);
       await this.usersService.updateStreak(userId);
+
+      const currentElo = await this.usersService.getElo(userId);
+      const questRating = questRatingFromDifficulties(
+        quest.questions.map((q) => q.difficulty),
+      );
+      eloDelta = calculateSoloEloDelta(currentElo, accuracy, questRating);
+      await this.usersService.updateElo(userId, eloDelta);
+      eloAfter = Math.max(0, currentElo + eloDelta);
     }
 
     if (quest.status !== 'completed') {
@@ -464,7 +478,9 @@ export class QuestsService {
       userId,
       attemptId: activeAttempt.id,
     });
-    return this.getQuestForPlay(questId, userId);
+
+    const questForPlay = await this.getQuestForPlay(questId, userId);
+    return { ...questForPlay, eloDelta, eloAfter };
   }
 
   private assertQuestPlayable(quest: Quest) {

--- a/openspec/changes/elo-from-quest-performance/design.md
+++ b/openspec/changes/elo-from-quest-performance/design.md
@@ -1,0 +1,118 @@
+# Design: ELO progression ladder from quest performance
+
+## Context
+
+- ELO math already exists in `backend/src/common/leagues.ts`: `expectedScore`,
+  `calculateEloDeltas` (multiplayer), `getLeague`, `LEAGUES`, `DEFAULT_ELO`,
+  `ELO_K_FACTOR`.
+- `usersService.updateElo(userId, delta)` persists to `stats.elo`, clamps
+  `>= 0`, and emits `user.elo_updated` only when `delta > 0`.
+- League medals `LEAGUE_*` (keyed by `minElo`) are evaluated by
+  `achievements.service.ts` on the `quest.completed` event.
+- `completeQuest` already computes `accuracy` and already has an
+  `attemptNumber === 1` branch that awards XP and updates the streak.
+
+## Goals / Non-goals
+
+- Goal: ELO starts at 0 and climbs (or dips) with real quest performance, gated
+  by question difficulty; league medals awarded on threshold crossings.
+- Non-goal: multiplayer ELO (`calculateEloDeltas` stays untouched), XP/level/coin
+  changes, new schema columns.
+
+## Decision 1 — Start the ladder at 0
+
+Set `DEFAULT_ELO = 0` in `leagues.ts`. Because entity defaults, seeds,
+matchmaking, and `users.service` fallbacks all import this constant (or should),
+the change propagates from one place. A one-off migration resets existing users'
+`stats.elo` to `0`.
+
+Trade-off: a brand-new/unlucky user can sit at `0` (Hierro) — that is the point;
+the climb must be earned. `updateElo` already clamps at `0`, so ELO never goes
+negative.
+
+## Decision 2 — Solo ELO delta formula
+
+Reuse the real ELO formula with **accuracy as the actual score** (continuous
+0..1) against a **virtual opponent** representing the quest's difficulty:
+
+```
+expected = expectedScore(currentElo, questRating)   // existing helper
+delta    = round(ELO_K_FACTOR * (accuracy - expected))
+newElo   = max(0, currentElo + delta)               // updateElo clamps
+```
+
+- `accuracy` = `correctAnswers / totalQuestions` (already computed in
+  `completeQuest`).
+- Self-balancing: you gain while `accuracy > expected`, lose while below, and
+  gains shrink to ~0 as your ELO climbs far above the quest's rating (perfect
+  play plateaus a few hundred points above `questRating`).
+
+New pure helper in `leagues.ts`:
+
+```ts
+export function calculateSoloEloDelta(
+  currentElo: number,
+  accuracy: number,      // 0..1
+  questRating: number,
+): number {
+  const expected = expectedScore(currentElo, questRating);
+  return Math.round(ELO_K_FACTOR * (accuracy - expected));
+}
+```
+
+## Decision 3 — Difficulty gates the climb
+
+Map each question's difficulty to an opponent rating aligned with the league
+ladder, then average across the quest's questions:
+
+```ts
+export const DIFFICULTY_RATINGS: Record<Difficulty, number> = {
+  easy: 400,     // caps solo climb around Plata/Oro
+  medium: 1200,  // caps around Platino
+  hard: 2000,    // needed to reach Diamante / QuestMaster
+};
+
+export function questRatingFromDifficulties(difficulties: Difficulty[]): number {
+  if (!difficulties.length) return DIFFICULTY_RATINGS.medium;
+  const sum = difficulties.reduce((a, d) => a + DIFFICULTY_RATINGS[d], 0);
+  return Math.round(sum / difficulties.length);
+}
+```
+
+Result: easy quests carry a new user up through the low leagues but plateau;
+reaching the top leagues requires consistently acing hard material. The three
+rating constants and `ELO_K_FACTOR` are the tuning knobs.
+
+Calibration sketch (steady accuracy `a` on quests of rating `R` settles ELO
+around `R + 400·log10(a/(1-a))`):
+
+| Quest content | Rating R | Plateau at a≈0.9 | League reached |
+|---------------|----------|------------------|----------------|
+| easy          | 400      | ~780             | Plata          |
+| medium        | 1200     | ~1580            | Platino        |
+| hard          | 2000     | ~2380            | Diamante→QM    |
+
+## Decision 4 — Ordering so medals are awarded correctly
+
+In `completeQuest`, call `updateElo` **before** the `quest.completed` event is
+emitted, so the achievements service sees the updated `stats.elo` when it
+re-evaluates the `LEAGUE_*` thresholds. Medals are permanent and never revoked on
+a later ELO drop (achievements are not removed).
+
+## Decision 5 — Surface the delta
+
+Extend the `completeQuest` response with `eloDelta` and `eloAfter` (and optionally
+`league`) for UX. The profile league/ELO display already reads `stats.elo`, so it
+updates without frontend changes; the delta is optional polish.
+
+## Risks
+
+- **Mis-calibration** (climb too fast/slow): mitigated by keeping ratings and
+  K-factor as named constants; adjust after observing real data.
+- **`DEFAULT_ELO` fan-out**: some spots may hardcode `1200` instead of importing
+  the constant — the tasks include an audit of every usage.
+- **Question difficulty not loaded** in `completeQuest`'s quest fetch: ensure the
+  questions relation includes `difficulty`, else fall back to `medium`.
+- **Negative-delta event gap**: `updateElo` emits `user.elo_updated` only on
+  `delta > 0`; league medals do not depend on it (they re-evaluate on
+  `quest.completed`), so no change needed — noted so it is not "fixed" by mistake.

--- a/openspec/changes/elo-from-quest-performance/proposal.md
+++ b/openspec/changes/elo-from-quest-performance/proposal.md
@@ -1,0 +1,82 @@
+# Change: ELO progression ladder from quest performance
+
+## Why
+
+Two progression systems live in `User.stats`, but only one runs:
+
+- **XP** works end to end. On the first attempt of a completed quest,
+  `completeQuest` awards XP via `usersService.addXp` and updates the streak
+  (`backend/src/modules/quests/quests.service.ts:450-453`).
+- **ELO** is fully scaffolded but never triggered. The math helpers
+  (`expectedScore`, `calculateEloDeltas`), the constants
+  (`DEFAULT_ELO = 1200`, `ELO_K_FACTOR = 32`), the persistence method
+  (`updateElo`, which clamps to `>= 0` and emits `user.elo_updated`), the 7
+  leagues, the leaderboards, the profile UI, and even the **league medals**
+  (`LEAGUE_*` achievements keyed by `minElo` in `achievements.service.ts`, which
+  re-evaluate on `quest.completed`) all exist — but no code path ever calls
+  `updateElo`. So a user's ELO is frozen and no league medal is ever earned.
+
+There is also a **design flaw** in the starting point: a new user starts at
+`DEFAULT_ELO = 1200`, which lands them in **Platino — the 4th of 7 leagues**.
+Starting halfway up the ladder makes "climbing" meaningless.
+
+This change turns ELO into a **progression ladder that starts at 0 (Hierro) and
+climbs with real quest performance**, gated by question difficulty, awarding the
+existing league medals as the user crosses thresholds. It reuses the XP flow that
+already works and does not touch multiplayer.
+
+> Naming note: starting at 0 and climbing makes this a **skill-progression
+> rating**, not a classic mean-reverting ELO. The name "ELO" and the league
+> tiers are kept; the semantics are a bottom-to-top ladder, which is the right
+> model for a solo study app.
+
+## What Changes
+
+- **Start at 0.** New users start at ELO `0` (Hierro) instead of `1200`. Change
+  the `DEFAULT_ELO` constant so every fallback, entity default, seed, and
+  leaderboard `COALESCE` follows.
+- **ELO moves on quest completion.** Inside the existing `attemptNumber === 1`
+  branch of `completeQuest` (next to `addXp`), compute an ELO delta from the
+  attempt's **accuracy** vs a virtual opponent whose rating is derived from the
+  quest's **average question difficulty**, then persist it with `updateElo`.
+- **Difficulty gates the climb.** Map question difficulty to an opponent rating
+  spanning the league ladder (easy/medium/hard → low/mid/high rating). Easy
+  quests carry you through the low leagues; reaching the top leagues requires
+  consistently mastering hard material. Averaged across the quest's questions.
+- **Medals come for free.** League medals (`LEAGUE_*`) already re-evaluate on
+  `quest.completed`, so once ELO moves they are awarded automatically as the user
+  crosses each league threshold. Medals are **permanent** — never revoked if ELO
+  later drops.
+- **Surface the change.** Return the ELO delta and new ELO in the `completeQuest`
+  response for optional UX (the profile league/ELO already reads `stats.elo`, so
+  it updates with no frontend change required).
+
+**Non-goals**
+
+- No multiplayer / PvP ELO wiring (future work; `calculateEloDeltas` untouched).
+- No new DB column or migration for schema — `stats.elo` already exists.
+  (A one-off data migration to reset existing users to 0 is a separate,
+  open decision — see Impact.)
+- No change to XP, level, coins, or streak computation.
+
+## Impact
+
+- Affected specs: `elo-rating` (new capability spec).
+- Affected code:
+  - `backend/src/common/leagues.ts` — change `DEFAULT_ELO` to `0`; add a pure
+    `calculateSoloEloDelta(currentElo, accuracy, questRating)` helper and a
+    difficulty→rating map. Keep `calculateEloDeltas` (multiplayer) untouched.
+  - `backend/src/modules/quests/quests.service.ts` — call `updateElo` inside the
+    existing `attemptNumber === 1` branch of `completeQuest`; derive the quest
+    rating from question difficulties; include the delta in the response.
+  - `backend/src/modules/users/user.entity.ts`, `database/seeds/seed.ts`,
+    `gateways/matchmaking/*`, and the `users.service.ts` fallbacks — verify they
+    inherit the new `DEFAULT_ELO` correctly.
+  - (optional) `frontend` — show the ELO delta after finishing a quest.
+- **Existing users (decided): reset all to 0.** A one-off data migration sets
+  every user's `stats.elo` to `0` so the ladder starts even for everyone at
+  Hierro. Existing league medals earned under the old 1200 start are left as-is
+  (achievements are permanent); new medals are earned by climbing for real.
+- Behavioral change: ELO now rises and falls with performance and gates on
+  difficulty; leagues and their medals become reachable from the bottom up. This
+  is intended.

--- a/openspec/changes/elo-from-quest-performance/specs/elo-rating/spec.md
+++ b/openspec/changes/elo-from-quest-performance/specs/elo-rating/spec.md
@@ -1,0 +1,75 @@
+# Spec delta: elo-rating
+
+## ADDED Requirements
+
+### Requirement: ELO ladder starts at zero
+New users SHALL start with an ELO of `0`, placing them in the lowest league
+(Hierro). The `DEFAULT_ELO` constant SHALL be `0` and SHALL be the single source
+of truth for entity defaults, seeds, matchmaking, and service fallbacks.
+
+#### Scenario: New user default ELO
+- **WHEN** a new user account is created
+- **THEN** their `stats.elo` is `0`
+- **AND** `getLeague(0)` returns the Hierro league
+
+#### Scenario: Existing users reset on migration
+- **WHEN** the ELO-reset data migration runs
+- **THEN** every existing user's `stats.elo` is set to `0`
+- **AND** previously earned league achievements are retained
+
+### Requirement: ELO changes on quest completion
+When a user completes a quest on their first attempt, the system SHALL adjust the
+user's ELO based on the attempt accuracy measured against the quest's difficulty
+rating, using the standard expected-score formula, and SHALL clamp the result to
+`>= 0`.
+
+#### Scenario: High accuracy raises ELO
+- **WHEN** a user completes a first attempt with accuracy above the expected
+  score for the quest's rating
+- **THEN** `stats.elo` increases by `round(ELO_K_FACTOR * (accuracy - expected))`
+- **AND** the increase is clamped so ELO never drops below `0`
+
+#### Scenario: Low accuracy lowers ELO
+- **WHEN** a user completes a first attempt with accuracy below the expected
+  score for the quest's rating
+- **THEN** `stats.elo` decreases by the same formula, clamped at `0`
+
+#### Scenario: Non-first attempts do not change ELO
+- **WHEN** a user completes a quest on a repeat attempt (`attemptNumber > 1`)
+- **THEN** `stats.elo` is unchanged
+
+### Requirement: Difficulty gates the climb
+The quest's virtual-opponent rating SHALL be derived from the average difficulty
+of its questions, so that easy content plateaus in the lower leagues and the top
+leagues require mastering harder content.
+
+#### Scenario: Difficulty maps to opponent rating
+- **WHEN** the quest rating is computed
+- **THEN** each question's difficulty maps to its configured rating
+  (`easy` < `medium` < `hard`)
+- **AND** the quest rating is the average of its questions' ratings
+- **AND** a quest with no difficulty data defaults to the `medium` rating
+
+### Requirement: League medals awarded on threshold crossings
+Crossing into a higher league SHALL award the corresponding league medal. The ELO
+update SHALL be applied before the `quest.completed` achievement evaluation so the
+new ELO is visible. Medals SHALL be permanent and SHALL NOT be revoked if ELO
+later drops below the threshold.
+
+#### Scenario: Reaching a new league awards its medal
+- **WHEN** an ELO increase moves the user across a league's `minElo`
+- **AND** the `quest.completed` achievement evaluation runs afterward
+- **THEN** the corresponding `LEAGUE_*` achievement is granted
+
+#### Scenario: Dropping a league keeps the medal
+- **WHEN** the user's ELO later falls below a league threshold they had crossed
+- **THEN** the previously granted league medal remains
+
+### Requirement: Quest completion reports the ELO change
+The `completeQuest` response SHALL include the ELO delta and the resulting ELO so
+clients can surface the change; profile league/ELO views SHALL reflect the updated
+`stats.elo` with no additional client change required.
+
+#### Scenario: Completion response includes ELO delta
+- **WHEN** a first-attempt quest completion changes the user's ELO
+- **THEN** the response includes `eloDelta` and `eloAfter`

--- a/openspec/changes/elo-from-quest-performance/tasks.md
+++ b/openspec/changes/elo-from-quest-performance/tasks.md
@@ -1,0 +1,57 @@
+# Tasks: ELO progression ladder from quest performance
+
+## 1. ELO math + constants (`backend/src/common/leagues.ts`)
+- [ ] 1.1 Change `DEFAULT_ELO` from `1200` to `0`.
+- [ ] 1.2 Add `DIFFICULTY_RATINGS` map (`easy: 400`, `medium: 1200`, `hard: 2000`)
+      and `questRatingFromDifficulties(difficulties)` helper (defaults to `medium`
+      when empty). Import the `Difficulty` type.
+- [ ] 1.3 Add pure `calculateSoloEloDelta(currentElo, accuracy, questRating)`
+      returning `round(ELO_K_FACTOR * (accuracy - expectedScore(currentElo, questRating)))`.
+- [ ] 1.4 Leave `calculateEloDeltas` (multiplayer) untouched.
+
+## 2. Audit `DEFAULT_ELO` fan-out
+- [ ] 2.1 Grep every `DEFAULT_ELO` and hardcoded `1200` in `backend/src`
+      (`user.entity.ts` default, `seed.ts`, `matchmaking/*`, `users.service.ts`
+      fallbacks and leaderboard `COALESCE`).
+- [ ] 2.2 Ensure each imports/uses the constant (no stray `1200`) so the new
+      start value is consistent everywhere.
+
+## 3. Wire ELO into quest completion (`backend/src/modules/quests/quests.service.ts`)
+- [ ] 3.1 In `completeQuest`, ensure the loaded quest's questions include
+      `difficulty` (adjust the fetch/select if needed).
+- [ ] 3.2 Inside the existing `attemptNumber === 1` branch, after `addXp`:
+      compute `questRating = questRatingFromDifficulties(quest.questions.map(q => q.difficulty))`,
+      then `delta = calculateSoloEloDelta(currentElo, accuracy, questRating)`,
+      then `await usersService.updateElo(userId, delta)`.
+- [ ] 3.3 Read `currentElo` via `usersService.getElo(userId)` before the update
+      to compute `eloAfter`.
+- [ ] 3.4 Ensure `updateElo` runs **before** the `quest.completed` event is
+      emitted (so achievements re-evaluate with the new ELO).
+- [ ] 3.5 Add `eloDelta` and `eloAfter` to the `completeQuest` return payload.
+
+## 4. Data migration — reset existing users
+- [ ] 4.1 Add a migration that sets `stats.elo = 0` for all users
+      (`UPDATE users SET stats = jsonb_set(stats, '{elo}', '0'::jsonb)`).
+- [ ] 4.2 Do NOT touch existing achievements/medals.
+
+## 5. Frontend (optional UX)
+- [ ] 5.1 Consume `eloDelta` / `eloAfter` in the quest-completion screen to show
+      the ELO change and any league-up.
+- [ ] 5.2 Confirm profile league/ELO (`ProfileHeader`, leaderboards) reflect the
+      updated `stats.elo` — should require no change since they read `stats.elo`.
+
+## 6. Tests
+- [ ] 6.1 Unit-test `calculateSoloEloDelta`: high accuracy → positive delta, low
+      accuracy → negative, clamp behavior via `updateElo`.
+- [ ] 6.2 Unit-test `questRatingFromDifficulties`: mixed difficulties average,
+      empty defaults to medium.
+- [ ] 6.3 Integration-test `completeQuest`: first attempt changes ELO and returns
+      `eloDelta`/`eloAfter`; repeat attempt does not change ELO.
+- [ ] 6.4 Verify a league-crossing completion grants the matching `LEAGUE_*`
+      achievement.
+
+## 7. Verification
+- [ ] 7.1 New user starts at `0` (Hierro); complete an easy quest and confirm ELO
+      rises and league updates on the profile.
+- [ ] 7.2 Confirm existing seeded users are at `0` after migration.
+- [ ] 7.3 Run backend test suite green.


### PR DESCRIPTION
## Qué hace

Convierte el ELO en una **escalera de progresión real**: arranca en 0 (Hierro) y sube (o baja) según el rendimiento en las quests, gateado por dificultad. Antes el ELO estaba cableado pero **nunca se disparaba**, y los usuarios arrancaban en 1200 (Platino, la 4ta de 7 ligas), así que "subir" no tenía sentido.

## Cambios

- **Arranca en 0**: `DEFAULT_ELO` 1200 → 0. Un usuario nuevo entra en Hierro.
- **El ELO se mueve al completar una quest** (solo primer intento, al lado del XP que ya andaba): `delta = round(K * (accuracy - expectedScore(elo, ratingDeLaQuest)))`, reusando la matemática ELO existente.
- **Gate por dificultad**: el rating de la quest sale del promedio de dificultad de sus preguntas (`easy→400`, `medium→1200`, `hard→2000`). Con quests fáciles plateás en las ligas bajas; para llegar a Diamante/QuestMaster hay que dominar material difícil.
- **Medallas gratis**: las medallas de liga (`LEAGUE_*`) ya se disparan con el evento `user.elo_updated` que emite `updateElo`. Cero trabajo extra. Permanentes (no se revocan si el ELO baja).
- **Migración**: resetea el `stats.elo` de todos los usuarios existentes a 0.
- El perfil y los leaderboards reflejan el nuevo `stats.elo` sin cambios de frontend.

## Fuera de scope (MVP)

- ELO multijugador / PvP (`calculateEloDeltas` queda intacto para el futuro).
- UX de feedback del `+ELO` en pantalla (el `completeQuest` ya devuelve `eloDelta`/`eloAfter` para cuando se quiera).

## Notas

- Las 3 constantes de dificultad y el `ELO_K_FACTOR` son las perillas de tuneo; se ajustan viendo datos reales.
- Plan completo en `openspec/changes/elo-from-quest-performance/`.
- ⚠️ Los tests unitarios nuevos (`leagues.spec.ts`) no corren localmente por un bug de entorno de jest preexistente (`clearMocksOnScope`, jest-runtime 30.4.2) que rompe **todas** las suites, no solo esta. Conviene arreglar el jest local/CI para que la nueva suite ejecute. El typecheck (`tsc --noEmit`) pasa limpio.

